### PR TITLE
ADD: Get the response code from a failing connection. (IDFGH-998)

### DIFF
--- a/include/mqtt_client.h
+++ b/include/mqtt_client.h
@@ -48,6 +48,16 @@ typedef enum {
     MQTT_EVENT_BEFORE_CONNECT,     /*!< The event occurs before connecting */
 } esp_mqtt_event_id_t;
 
+enum mqtt_connect_return_code
+{
+    CONNECTION_ACCEPTED = 0,
+    CONNECTION_REFUSE_PROTOCOL,
+    CONNECTION_REFUSE_ID_REJECTED,
+    CONNECTION_REFUSE_SERVER_UNAVAILABLE,
+    CONNECTION_REFUSE_BAD_USERNAME,
+    CONNECTION_REFUSE_NOT_AUTHORIZED
+};
+
 typedef enum {
     MQTT_TRANSPORT_UNKNOWN = 0x0,
     MQTT_TRANSPORT_OVER_TCP,      /*!< MQTT over TCP, using scheme: ``mqtt`` */
@@ -71,6 +81,7 @@ typedef struct {
     int topic_len;                      /*!< Length of the topic for this event asociated with this event */
     int msg_id;                         /*!< MQTT messaged id of message */
     int session_present;                /*!< MQTT session_present flag for connection event */
+    uint8_t connect_return_code;		/*!< MQTT connection return code. Only written on a connection */
 } esp_mqtt_event_t;
 
 typedef esp_mqtt_event_t* esp_mqtt_event_handle_t;

--- a/lib/include/mqtt_msg.h
+++ b/lib/include/mqtt_msg.h
@@ -58,16 +58,6 @@ enum mqtt_message_type
     MQTT_MSG_TYPE_DISCONNECT = 14
 };
 
-enum mqtt_connect_return_code
-{
-    CONNECTION_ACCEPTED = 0,
-    CONNECTION_REFUSE_PROTOCOL,
-    CONNECTION_REFUSE_ID_REJECTED,
-    CONNECTION_REFUSE_SERVER_UNAVAILABLE,
-    CONNECTION_REFUSE_BAD_USERNAME,
-    CONNECTION_REFUSE_NOT_AUTHORIZED
-};
-
 typedef struct mqtt_message
 {
     uint8_t* data;

--- a/lib/mqtt_msg.c
+++ b/lib/mqtt_msg.c
@@ -273,13 +273,13 @@ uint16_t mqtt_get_id(uint8_t* buffer, uint16_t length)
                 topiclen = buffer[i++] << 8;
                 topiclen |= buffer[i++];
 
-                if (i + topiclen >= length)
+                if (i + topiclen > length)
                     return 0;
                 i += topiclen;
 
                 if (mqtt_get_qos(buffer) > 0)
                 {
-                    if (i + 2 >= length)
+                    if (i + 2 > length)
                         return 0;
                     //i += 2;
                 } else {

--- a/mqtt_client.c
+++ b/mqtt_client.c
@@ -67,6 +67,16 @@ typedef enum {
     MQTT_STATE_WAIT_TIMEOUT,
 } mqtt_client_state_t;
 
+/* State values for reading MQTT message header */
+typedef enum {
+	MQTT_MSG_STATE_ANALYSE 				= -4,	//!< MQTT MSG will be analysed
+    MQTT_MSG_STATE_HEADER_INCOMPLETE 	= -3,   //!< MQTT MSG HEADER is incomplete
+    MQTT_MSG_STATE_HEADER_COMPLETE 		= -2,   //!< MQTT MSG HEADER is complete
+	MQTT_MSG_STATE_PAYLOAD_INCOMPLETE 	= -1,   //!< MQTT MSG PAYLOAD is incomplete
+	MQTT_MSG_STATE_COMPLETE 			=  0    //!< MQTT MSG is completed.
+} mqtt_msg_state_t;
+
+
 struct esp_mqtt_client {
     esp_transport_list_handle_t transport_list;
     esp_transport_handle_t transport;
@@ -541,73 +551,125 @@ static esp_err_t esp_mqtt_dispatch_event(esp_mqtt_client_handle_t client)
 
 static void deliver_publish(esp_mqtt_client_handle_t client, uint8_t *message, int length)
 {
+	mqtt_msg_state_t mqtt_msg_state = MQTT_MSG_STATE_ANALYSE;
     const char *mqtt_topic = NULL, *mqtt_data = NULL;
     uint32_t mqtt_topic_length, mqtt_data_length;
-    uint32_t mqtt_len = 0, mqtt_offset = 0, total_mqtt_len = 0;
+    uint32_t mqtt_len = 0, mqtt_offset = 0;
     int len_read= length;
     int max_to_read = client->mqtt_state.in_buffer_length;
     int buffer_offset = 0;
+    uint8_t mqtt_fixed_header_length, mqtt_variable_header_length = 0;
     esp_transport_handle_t transport = client->transport;
 
     do
     {
-        if (total_mqtt_len == 0) {
-            /* any further reading only the underlying payload */
-            transport = esp_transport_get_payload_transport_handle(transport);
-            mqtt_data_length = mqtt_topic_length = length;
-            if (NULL == (mqtt_topic = mqtt_get_publish_topic(message, &mqtt_topic_length)) ||
-                NULL == (mqtt_data = mqtt_get_publish_data(message, &mqtt_data_length)) ) {
-                // mqtt header is not complete, continue reading
-                memmove(client->mqtt_state.in_buffer, message, length);
-                buffer_offset = length;
-                message = client->mqtt_state.in_buffer;
-                max_to_read = client->mqtt_state.in_buffer_length - length;
-                mqtt_len = 0;
-            } else {
-                total_mqtt_len = client->mqtt_state.message_length - client->mqtt_state.message_length_read + mqtt_data_length;
-                mqtt_len = mqtt_data_length;
-                mqtt_data_length = client->mqtt_state.message_length - ((uint8_t*)mqtt_data- message);
-                /* read msg id only once */
-                client->event.msg_id = mqtt_get_id(message, length);
-            }
-        } else {
-            mqtt_len = len_read;
-            mqtt_data = (const char*)client->mqtt_state.in_buffer;
-            mqtt_topic = NULL;
-            mqtt_topic_length = 0;
-        }
+    	ESP_LOGD(TAG, "MQTT_MSG_STATE: %d", mqtt_msg_state);
 
-        if (total_mqtt_len != 0) {
-            ESP_LOGD(TAG, "Get data len= %d, topic len=%d", mqtt_len, mqtt_topic_length);
-            client->event.event_id = MQTT_EVENT_DATA;
-            client->event.data = (char *)mqtt_data;
-            client->event.data_len = mqtt_len;
-            client->event.total_data_len = mqtt_data_length;
-            client->event.current_data_offset = mqtt_offset;
-            client->event.topic = (char *)mqtt_topic;
-            client->event.topic_len = mqtt_topic_length;
-            esp_mqtt_dispatch_event(client);
-        }
+    	switch(mqtt_msg_state)
+    	{
+    	case MQTT_MSG_STATE_ANALYSE:
+    	{
+    		mqtt_msg_state = MQTT_MSG_STATE_HEADER_INCOMPLETE;
 
-        mqtt_offset += mqtt_len;
-        if (client->mqtt_state.message_length_read >= client->mqtt_state.message_length) {
-            break;
-        }
+    		transport = esp_transport_get_payload_transport_handle(transport);
+    		mqtt_topic_length = length;
+    		mqtt_topic = mqtt_get_publish_topic(message, &mqtt_topic_length);
+    		if(mqtt_topic == NULL) // not enough data to get the topic
+    		{
+    			break;	// exit the switch and get more data.
+    		}
 
-        len_read = esp_transport_read(transport,
-                                  (char *)client->mqtt_state.in_buffer + buffer_offset,
-                                  client->mqtt_state.message_length - client->mqtt_state.message_length_read > max_to_read ?
-                                  max_to_read : client->mqtt_state.message_length - client->mqtt_state.message_length_read,
-                                  client->config->network_timeout_ms);
-        length = len_read + buffer_offset;
-        buffer_offset = 0;
-        max_to_read = client->mqtt_state.in_buffer_length;
-        if (len_read <= 0) {
-            ESP_LOGE(TAG, "Read error or timeout: len_read=%d, errno=%d", len_read, errno);
-            break;
-        }
-        client->mqtt_state.message_length_read += len_read;
-    } while (1);
+    		int i;
+
+    		for (i = 1; i < length; ++i)		// Count the number of bytes for the message length ( Starting after the FLAGS)
+    		{
+    			if ((message[i] & 0x80) == 0)	// Check for continuation bit
+    			{
+    				++i;
+    				break;
+    			}
+    		}
+    		mqtt_fixed_header_length = i; 		// Fixed Header = FLAGS [1 Byte] + msg length ( 1-4 Bytes [i])
+
+    		mqtt_variable_header_length = 2 + mqtt_topic_length;	// Topic length (2 Bytes) + actual topic data
+    		if(mqtt_get_qos(message)> 0 ) 							// QOS1 and QOS2 include the Packet Identifier
+    		{
+    			mqtt_variable_header_length+=2;						//  Packet Identifier (2 Bytes)
+    		}
+
+    		if(client->mqtt_state.message_length_read > mqtt_fixed_header_length + mqtt_variable_header_length)
+    		{
+    			mqtt_msg_state = MQTT_MSG_STATE_HEADER_COMPLETE;	// HEADER is OK, but the msg contains a payload. (Total mqtt msg len > headers len)
+    		}
+    		if(client->mqtt_state.message_length_read == mqtt_fixed_header_length + mqtt_variable_header_length)
+    		{
+    			mqtt_msg_state = MQTT_MSG_STATE_COMPLETE;	// Message was only the HEADER. So it's complete!	(Total mqtt msg len == headers len)
+    		}
+    		break;
+    	}
+    	case MQTT_MSG_STATE_HEADER_COMPLETE:
+    	{
+    		mqtt_msg_state = MQTT_MSG_STATE_PAYLOAD_INCOMPLETE;
+    		mqtt_data_length = length;
+    		mqtt_data = mqtt_get_publish_data(message, &mqtt_data_length);
+    		if(mqtt_data == NULL)
+    		{
+    			break;
+    		}
+    		if(client->mqtt_state.message_length_read == mqtt_fixed_header_length + mqtt_variable_header_length + mqtt_data_length)
+    		{
+    			mqtt_msg_state = MQTT_MSG_STATE_COMPLETE;	// Message  it's complete!	(Total mqtt msg len == headers len + payload len)
+    		}
+    		break;
+    	}
+    	default:
+    		break;
+    	}	// switch
+
+    	if(	mqtt_msg_state == MQTT_MSG_STATE_HEADER_INCOMPLETE ||
+    		mqtt_msg_state == MQTT_MSG_STATE_PAYLOAD_INCOMPLETE	)
+    	{
+    		memmove(client->mqtt_state.in_buffer, message, length);
+    		buffer_offset = length;
+    		message = client->mqtt_state.in_buffer;
+    		max_to_read = client->mqtt_state.in_buffer_length - length;
+    		mqtt_len = 0;
+
+    		mqtt_offset += mqtt_len;
+
+    		len_read = esp_transport_read(transport,
+    				(char *)client->mqtt_state.in_buffer + buffer_offset,
+					client->mqtt_state.message_length - client->mqtt_state.message_length_read > max_to_read ?
+							max_to_read : client->mqtt_state.message_length - client->mqtt_state.message_length_read,
+							client->config->network_timeout_ms);
+    		length = len_read + buffer_offset;
+    		ESP_LOGD(TAG, "MQTT read %d", len_read);
+    		max_to_read = client->mqtt_state.in_buffer_length;
+
+    		if (len_read <= 0) {
+    			ESP_LOGE(TAG, "Read error or timeout: len_read=%d, errno=%d", len_read, errno);
+    			break;
+    		}
+    		client->mqtt_state.message_length_read += len_read;
+    	}
+
+    	if( mqtt_msg_state == MQTT_MSG_STATE_COMPLETE)
+    	{
+    		ESP_LOGD(TAG, "MQTT_MSG_STATE_HEADER_COMPLETE - send evt");
+    		ESP_LOGD(TAG, "Get data len= %d, topic len=%d", mqtt_len, mqtt_topic_length);
+    		client->event.event_id = MQTT_EVENT_DATA;
+    		client->event.data = (char *)mqtt_data;
+    		client->event.data_len = mqtt_len;
+    		client->event.total_data_len = mqtt_data_length;
+    		client->event.current_data_offset = mqtt_offset;
+    		client->event.topic = (char *)mqtt_topic;
+    		client->event.topic_len = mqtt_topic_length;
+    		esp_mqtt_dispatch_event(client);
+
+    		return;
+    	}
+
+    }while(1);
 
 }
 


### PR DESCRIPTION
This commit adds an event information "connect_return_code" that is written
when the client state is MQTT_STATE_INIT, and the connection fails.

This event info can then be written by the user app to find out the reason
of the fail connection.