### PR TITLE
FIX: mqtt_get_id && handle msg without a payload  (IDFGH-1025)

### DIFF
--- a/lib/mqtt_msg.c
+++ b/lib/mqtt_msg.c
@@ -273,13 +273,13 @@ uint16_t mqtt_get_id(uint8_t* buffer, uint16_t length)
                 topiclen = buffer[i++] << 8;
                 topiclen |= buffer[i++];
 
-                if (i + topiclen >= length)
+                if (i + topiclen > length)
                     return 0;
                 i += topiclen;
 
                 if (mqtt_get_qos(buffer) > 0)
                 {
-                    if (i + 2 >= length)
+                    if (i + 2 > length)
                         return 0;
                     //i += 2;
                 } else {


### PR DESCRIPTION
Found 2 problems with the current idf branch.
* The mqtt_get_id function logic is wrong and return 0 when it shouldn't
* The deliver_publish fuinction can't handle messages without a payload.

This PR solves booth issues.