### PR TITLE
Publish null data (IDFGH-1127)

### DIFF
--- a/lib/mqtt_msg.c
+++ b/lib/mqtt_msg.c
@@ -440,8 +440,11 @@ mqtt_message_t* mqtt_msg_publish(mqtt_connection_t* connection, const char* topi
         connection->message.length = connection->buffer_length;
         connection->message.fragmented_msg_total_length = data_length + connection->message.fragmented_msg_data_offset;
     } else {
-        memcpy(connection->buffer + connection->message.length, data, data_length);
-        connection->message.length += data_length;
+        if (data != NULL)
+        {
+            memcpy(connection->buffer + connection->message.length, data, data_length);
+            connection->message.length += data_length;
+        }
         connection->message.fragmented_msg_total_length = 0;
     }
     return fini_message(connection, MQTT_MSG_TYPE_PUBLISH, 0, qos, retain);

--- a/lib/mqtt_msg.c
+++ b/lib/mqtt_msg.c
@@ -422,6 +422,9 @@ mqtt_message_t* mqtt_msg_publish(mqtt_connection_t* connection, const char* topi
     if (append_string(connection, topic, strlen(topic)) < 0)
         return fail_message(connection);
 
+    if (data == NULL && data_length > 0)
+        return fail_message(connection);
+
     if (qos > 0)
     {
         if ((*message_id = append_message_id(connection, 0)) == 0)


### PR DESCRIPTION
Add some simple checks to handle the case where the pointer on the data to be published is null. Not quite sure what to do with the case where we have a fragmented message : can this happen without a payload ? Can this `connection->message.length > connection->buffer_length` be true ?