### PR TITLE
Support larger buffers and messages (IDFGH-2505)

### DIFF
--- a/lib/include/mqtt_msg.h
+++ b/lib/include/mqtt_msg.h
@@ -1,5 +1,8 @@
 #ifndef MQTT_MSG_H
 #define MQTT_MSG_H
+#include <stdint.h>
+#include <stdbool.h>
+
 #include "mqtt_config.h"
 #ifdef  __cplusplus
 extern "C" {
@@ -69,7 +72,7 @@ typedef struct mqtt_connection {
 
     uint16_t message_id;
     uint8_t *buffer;
-    uint16_t buffer_length;
+    uint32_t buffer_length;
 
 } mqtt_connection_t;
 
@@ -117,13 +120,13 @@ static inline int mqtt_get_retain(uint8_t *buffer)
     return (buffer[0] & 0x01);
 }
 
-void mqtt_msg_init(mqtt_connection_t *connection, uint8_t *buffer, uint16_t buffer_length);
-bool mqtt_header_complete(uint8_t *buffer, uint16_t buffer_length);
-uint32_t mqtt_get_total_length(uint8_t *buffer, uint16_t length, int *fixed_size_len);
+void mqtt_msg_init(mqtt_connection_t *connection, uint8_t *buffer, uint32_t buffer_length);
+bool mqtt_header_complete(uint8_t *buffer, uint32_t buffer_length);
+uint32_t mqtt_get_total_length(uint8_t *buffer, uint32_t length, int *fixed_size_len);
 char *mqtt_get_publish_topic(uint8_t *buffer, uint32_t *length);
 char *mqtt_get_publish_data(uint8_t *buffer, uint32_t *length);
-uint16_t mqtt_get_id(uint8_t *buffer, uint16_t length);
-int mqtt_has_valid_msg_hdr(uint8_t *buffer, uint16_t length);
+uint16_t mqtt_get_id(uint8_t *buffer, uint32_t length);
+int mqtt_has_valid_msg_hdr(uint8_t *buffer, uint32_t length);
 
 mqtt_message_t *mqtt_msg_connect(mqtt_connection_t *connection, mqtt_connect_info_t *info);
 mqtt_message_t *mqtt_msg_publish(mqtt_connection_t *connection, const char *topic, const char *data, int data_length, int qos, int retain, uint16_t *message_id);

--- a/lib/mqtt_msg.c
+++ b/lib/mqtt_msg.c
@@ -28,8 +28,6 @@
 * POSSIBILITY OF SUCH DAMAGE.
 *
 */
-#include <stdint.h>
-#include <stdbool.h>
 #include <string.h>
 #include "mqtt_msg.h"
 #include "mqtt_config.h"
@@ -147,14 +145,14 @@ static mqtt_message_t *fini_message(mqtt_connection_t *connection, int type, int
     return &connection->message;
 }
 
-void mqtt_msg_init(mqtt_connection_t *connection, uint8_t *buffer, uint16_t buffer_length)
+void mqtt_msg_init(mqtt_connection_t *connection, uint8_t *buffer, uint32_t buffer_length)
 {
     memset(connection, 0, sizeof(mqtt_connection_t));
     connection->buffer = buffer;
     connection->buffer_length = buffer_length;
 }
 
-uint32_t mqtt_get_total_length(uint8_t *buffer, uint16_t length, int *fixed_size_len)
+uint32_t mqtt_get_total_length(uint8_t *buffer, uint32_t length, int *fixed_size_len)
 {
     int i;
     uint32_t totlen = 0;
@@ -174,7 +172,7 @@ uint32_t mqtt_get_total_length(uint8_t *buffer, uint16_t length, int *fixed_size
     return totlen;
 }
 
-bool mqtt_header_complete(uint8_t *buffer, uint16_t buffer_length)
+bool mqtt_header_complete(uint8_t *buffer, uint32_t buffer_length)
 {
     uint16_t i;
     uint16_t topiclen;
@@ -282,7 +280,7 @@ char *mqtt_get_publish_data(uint8_t *buffer, uint32_t *length)
     return (char *)(buffer + i);
 }
 
-uint16_t mqtt_get_id(uint8_t *buffer, uint16_t length)
+uint16_t mqtt_get_id(uint8_t *buffer, uint32_t length)
 {
     if (length < 1) {
         return 0;
@@ -560,7 +558,7 @@ mqtt_message_t *mqtt_msg_disconnect(mqtt_connection_t *connection)
  * check flags: [MQTT-2.2.2-1], [MQTT-2.2.2-2]
  * returns 0 if flags are invalid, otherwise returns 1
  */
-int mqtt_has_valid_msg_hdr(uint8_t *buffer, uint16_t length)
+int mqtt_has_valid_msg_hdr(uint8_t *buffer, uint32_t length)
 {
     int qos, dup;
 


### PR DESCRIPTION
Use `uint32_t` instead of `uint16_t` for message and buffer lengths.
This is necessary for receiving messages that are larger than 65K.