### PR TITLE
mqtt: Add esp_mqtt_client_get_outbox_size API

### DIFF
--- a/include/mqtt_client.h
+++ b/include/mqtt_client.h
@@ -348,6 +348,14 @@ esp_err_t esp_mqtt_set_config(esp_mqtt_client_handle_t client, const esp_mqtt_cl
  */
 esp_err_t esp_mqtt_client_register_event(esp_mqtt_client_handle_t client, esp_mqtt_event_id_t event, esp_event_handler_t event_handler, void* event_handler_arg);
 
+/**
+ * @brief Get outbox size
+ *
+ * @param client            mqtt client handle
+ * @return outbox size
+ */
+int esp_mqtt_client_get_outbox_size(esp_mqtt_client_handle_t client);
+
 #ifdef __cplusplus
 }
 #endif //__cplusplus

--- a/mqtt_client.c
+++ b/mqtt_client.c
@@ -1757,3 +1757,22 @@ static void esp_mqtt_client_dispatch_tls_error(esp_mqtt_client_handle_t client)
 #endif
         esp_mqtt_dispatch_event_with_msgid(client);
 }
+
+int esp_mqtt_client_get_outbox_size(esp_mqtt_client_handle_t client)
+{
+    int outbox_size = 0;
+
+    if (client == NULL) {
+        return 0;
+    }
+
+    MQTT_API_LOCK(client);
+
+    if (client->outbox) {
+        outbox_size = outbox_get_size(client->outbox);
+    }
+
+    MQTT_API_UNLOCK(client);
+
+    return outbox_size;
+}


### PR DESCRIPTION
Allow application to get current outbox_size.
Application may try to send many publish request for a long period and then
system can hit OOM when publish QoS>1 with a busy borker.
Reduce OUTBOX_EXPIRED_TIMEOUT_MS does not help too much because the publish
freauency depends on the data received in different environment.
i.e. In some environment, sometimes it's easy to hit OOM before reaching OUTBOX_EXPIRED_TIMEOUT_MS.

To avoid such issue, add esp_mqtt_client_get_outbox_size API, so the application
can stop publishing to avoid OOM when outbox takes too much memory.

Signed-off-by: Axel Lin <axel.lin@ingics.com>