### PR TITLE
mqtt: Remove unused mqtt_header_state_t

### DIFF
--- a/mqtt_client.c
+++ b/mqtt_client.c
@@ -93,12 +93,6 @@ typedef enum {
     MQTT_STATE_WAIT_TIMEOUT,
 } mqtt_client_state_t;
 
-/* State values for reading MQTT message header */
-typedef enum {
-    MQTT_HEADER_STATE_INCOMPLETE = -1,
-    MQTT_HEADER_STATE_COMPLETE = 0,
-} mqtt_header_state_t;
-
 struct esp_mqtt_client {
     esp_transport_list_handle_t transport_list;
     esp_transport_handle_t transport;


### PR DESCRIPTION
mqtt_header_state_t was added by commit 0450bd009397 ("MQTT Client:  Added support for receiving empty payload"),
but it's no longer used since commit fd564b1f1733 ("client receive: refactor receive to read only one message to fragment only payload for longer messages").
Thus remove the unused mqtt_header_state_t.

Signed-off-by: Axel Lin <axel.lin@ingics.com>