### PR TITLE
mqtt_msg: Allow set zero length username if password is set (IDFGH-4591)

### DIFF
--- a/lib/mqtt_msg.c
+++ b/lib/mqtt_msg.c
@@ -410,6 +410,17 @@ mqtt_message_t *mqtt_msg_connect(mqtt_connection_t *connection, mqtt_connect_inf
     }
 
     if (info->password != NULL && info->password[0] != '\0') {
+        if (info->username == NULL || info->username[0] == '\0') {
+            /* MQTT-3.1.2-20: If the User Name Flag is set to 0 then the Password Flag MUST be set to 0.
+               In case if password is set without username, we need to set a zero length username.
+             */
+            if (append_string(connection, "", 0) < 0) {
+                return fail_message(connection);
+            }
+
+            variable_header[flags_offset] |= MQTT_CONNECT_FLAG_USERNAME;
+        }
+
         if (append_string(connection, info->password, strlen(info->password)) < 0) {
             return fail_message(connection);
         }


### PR DESCRIPTION
Some cloud server (e.g. exosite) takes empty username with password.
Current esp-mqtt implementation does not allow such setting, fix it.

Current users may already consider strlen(info->username) == 0 case as
don't set username. To avoid breaking existing behavior, this patch only
set zero length username when password is set.

Signed-off-by: Axel Lin <axel.lin@ingics.com>