### PR TITLE
mqtt_outbox: Use STAILQ_FOREACH for outbox_delete_single_expired

### DIFF
--- a/lib/mqtt_outbox.c
+++ b/lib/mqtt_outbox.c
@@ -168,8 +168,8 @@ esp_err_t outbox_delete_msgtype(outbox_handle_t outbox, int msg_type)
 int outbox_delete_single_expired(outbox_handle_t outbox, outbox_tick_t current_tick, outbox_tick_t timeout)
 {
     int msg_id = -1;
-    outbox_item_handle_t item, tmp;
-    STAILQ_FOREACH_SAFE(item, outbox, next, tmp) {
+    outbox_item_handle_t item;
+    STAILQ_FOREACH(item, outbox, next) {
         if (current_tick - item->tick > timeout) {
             STAILQ_REMOVE(outbox, item, outbox_item, next);
             free(item->buffer);


### PR DESCRIPTION
For the delete one entry and return case, no need to use STAILQ_FOREACH_SAFE.

Signed-off-by: Axel Lin <axel.lin@ingics.com>