### PR TITLE
ESP x509 Certificate Bundle for MQTTS (IDFGH-5277)

### DIFF
--- a/include/mqtt_client.h
+++ b/include/mqtt_client.h
@@ -191,6 +191,7 @@ typedef struct {
     int refresh_connection_after_ms;        /*!< Refresh connection after this value (in milliseconds) */
     const struct psk_key_hint *psk_hint_key;     /*!< Pointer to PSK struct defined in esp_tls.h to enable PSK authentication (as alternative to certificate verification). If not NULL and server/client certificates are NULL, PSK is enabled */
     bool          use_global_ca_store;      /*!< Use a global ca_store for all the connections in which this bool is set. */
+    esp_err_t ((*crt_bundle_attach)(void *conf)); /*!< Use ESP x509 Certificate Bundle for mqtts
     int reconnect_timeout_ms;               /*!< Reconnect to the broker after this value in miliseconds if auto reconnect is not disabled (defaults to 10s) */
     const char **alpn_protos;               /*!< NULL-terminated list of supported application protocols to be used for ALPN */
     const char *clientkey_password;         /*!< Client key decryption password string */

--- a/mqtt_client.c
+++ b/mqtt_client.c
@@ -78,6 +78,7 @@ typedef struct {
     char *clientkey_password;
     int clientkey_password_len;
     bool use_global_ca_store;
+    esp_err_t ((*crt_bundle_attach)(void *conf));
     const char *cacert_buf;
     size_t cacert_bytes;
     const char *clientcert_buf;
@@ -206,6 +207,10 @@ static esp_err_t esp_mqtt_set_ssl_transport_properties(esp_transport_list_handle
     } else {
         ESP_OK_CHECK(TAG, esp_mqtt_set_cert_key_data(ssl, MQTT_SSL_DATA_API_CA_CERT, cfg->cacert_buf, cfg->cacert_bytes),
                      goto esp_mqtt_set_transport_failed);
+    }
+
+    if (cfg->crt_bundle_attach != NULL) {
+        esp_transport_ssl_crt_bundle_attach(ssl, cfg->crt_bundle_attach);
     }
 
     if (cfg->use_secure_element) {
@@ -480,6 +485,7 @@ esp_err_t esp_mqtt_set_config(esp_mqtt_client_handle_t client, const esp_mqtt_cl
     client->config->psk_hint_key = config->psk_hint_key;
     client->config->skip_cert_common_name_check = config->skip_cert_common_name_check;
     client->config->use_secure_element = config->use_secure_element;
+    client->config->crt_bundle_attach = config->crt_bundle_attach;
     client->config->ds_data = config->ds_data;
 
     if (config->clientkey_password && config->clientkey_password_len) {


### PR DESCRIPTION
Added functionality to use certificate bundles for mqtt connections --> [see this feature request](https://github.com/espressif/esp-mqtt/issues/190)