### PR TITLE
mqtt_client: fix esp_mqtt_client_enqueue for len=0

### DIFF
--- a/mqtt_client.c
+++ b/mqtt_client.c
@@ -1917,6 +1917,16 @@ int esp_mqtt_client_enqueue(esp_mqtt_client_handle_t client, const char *topic, 
         ESP_LOGE(TAG, "Client was not initialized");
         return -1;
     }
+
+    /* Acceptable publish messages:
+        data == NULL, len == 0: publish null message
+        data valid,   len == 0: publish all data, payload len is determined from string length
+        data valid,   len >  0: publish data with defined length
+     */
+    if (len <= 0 && data != NULL) {
+        len = strlen(data);
+    }
+
     MQTT_API_LOCK(client);
     int ret = mqtt_client_enqueue_priv(client, topic, data, len, qos, retain, store);
     MQTT_API_UNLOCK(client);


### PR DESCRIPTION
Updated esp-idf to latest master and saw a problem were messages sent with esp_mqtt_client_enqueue appeared to send but no data was seen. Bisecting pointed to commit 372b323 (mqtt_client: Fix mqtt send long data error, 2021-12-21).

The length calculation was removed from esp_mqtt_client_enqueue_priv and added to esp_mqtt_client_publish. However, it appears esp_mqtt_client_enqueue was missed. Currently calls to esp_mqtt_client_enqueue appear to send no data, fix this by adding the length calculation to esp_mqtt_client_enqueue.