### PR TITLE
Add esp_tls option to skip server verification

### DIFF
--- a/include/mqtt_client.h
+++ b/include/mqtt_client.h
@@ -187,6 +187,7 @@ typedef struct esp_mqtt_client_config_t {
     size_t cert_len;                        /*!< Length of the buffer pointed to by cert_pem. May be 0 for null-terminated pem */
     const struct psk_key_hint *psk_hint_key;     /*!< Pointer to PSK struct defined in esp_tls.h to enable PSK authentication (as alternative to certificate verification). If not NULL and server certificates are NULL, PSK is enabled */
     bool skip_cert_common_name_check;       /*!< Skip any validation of server certificate CN field, this reduces the security of TLS and makes the mqtt client susceptible to MITM attacks  */
+    bool skip_server_verification;          /*!< Skip server verification completely. Should only be used for debugging */
     const char **alpn_protos;               /*!< NULL-terminated list of supported application protocols to be used for ALPN */
     const char *username;                   /*!< MQTT username */
     const char *password;                   /*!< MQTT password */

--- a/mqtt_client.c
+++ b/mqtt_client.c
@@ -228,6 +228,8 @@ static esp_err_t esp_mqtt_set_ssl_transport_properties(esp_transport_list_handle
 
     if (cfg->use_global_ca_store == true) {
         esp_transport_ssl_enable_global_ca_store(ssl);
+    } else if (cfg->skip_server_verification == true) {
+        esp_transport_ssl_skip_server_verification(ssl);
     } else if (cfg->crt_bundle_attach != NULL) {
 #ifdef MQTT_SUPPORTED_FEATURE_CERTIFICATE_BUNDLE
 #ifdef CONFIG_MBEDTLS_CERTIFICATE_BUNDLE


### PR DESCRIPTION
I added a tls option to skip server verification completely for debugging purposes without turning on the dangerous compile time flag `CONFIG_ESP_TLS_SKIP_SERVER_CERT_VERIFY`.

This pull request needs another pull request of mine be merged first:
https://github.com/espressif/esp-idf/pull/9147