### PR TITLE
Improve/fix handling of read errors (IDFGH-7937)

### DIFF
--- a/mqtt_client.c
+++ b/mqtt_client.c
@@ -1181,7 +1181,7 @@ static int mqtt_message_receive(esp_mqtt_client_handle_t client, int read_poll_t
          */
         read_len = esp_transport_read(t, (char *)buf, 1, read_poll_timeout_ms);
         if (read_len <= 0) {
-            if (err == ERR_TCP_TRANSPORT_CONNECTION_TIMEOUT) {
+            if (read_len == ERR_TCP_TRANSPORT_CONNECTION_TIMEOUT) {
                 ESP_LOGD(TAG, "No data received in %dms (all is quiet)", read_poll_timeout_ms);
                 return 0;
             } else {

--- a/mqtt_client.c
+++ b/mqtt_client.c
@@ -1144,7 +1144,7 @@ static outbox_item_handle_t mqtt_enqueue(esp_mqtt_client_handle_t client)
 
 /*
  * Returns:
- *     -1 in case of failure
+ *      -1 for failure or connection timeout/close in the middle of a message
  *      0 if no message has been received
  *      1 if a message has been received and placed to client->mqtt_state:
  *           message length:  client->mqtt_state.message_length


### PR DESCRIPTION
(Edited)

This change simplifies and should correct socket error handling in the MQTT implementation for all ESP-IDF and MQTT versions, giving improved performance and correctness.

Explanation:

Previously, an error (return value <= 0) from `esp_transport_read()` from any locus was followed by a call to `esp_mqtt_handle_transport_read_error()`, whose semantics are unclear but would return 0 for closed connection OR timeout, and return -1 (and log an error) for any other error type. The calling sites would generally return error for -1, and return success (but still abandon the operation) for 0.

This was often not quite right.
- When waiting on an idle socket for a message, a timeout is not an error, but a closed connection IS an error. Handling a closed connection as a non-error delays recognition of a closed connection (it has to be discovered when a message/keepalive is sent, or by failing an idleness check).
- When waiting for the rest of a message body, both timeout (generally the 10sec network timeout) and closed connection are errors. In any case returning ESP_OK when the operation did not actually succeed is not right.

Change:

Revise the error handling to make `esp_mqtt_handle_transport_read_error()` unconditionally describe the error and call `esp_mqtt_client_dispatch_transport_error()`. The one place where timeouts should be accepted (the first-byte read) wraps that call accordingly. Comments are added and error messages improved.