### PR TITLE
feature: Include subscribe_id in esp_mqtt5_event_property_t (IDFGH-9474)

### DIFF
--- a/include/mqtt5_client.h
+++ b/include/mqtt5_client.h
@@ -138,6 +138,7 @@ typedef struct {
     uint16_t correlation_data_len;      /*!< Correlation data length of the message */
     char *content_type;                 /*!< Content type of the message */
     int content_type_len;               /*!< Content type length of the message */
+    uint16_t subscribe_id;              /*!< Subscription identifier of the message */
     mqtt5_user_property_handle_t user_property;  /*!< The handle for user property, call function esp_mqtt5_client_delete_user_property to free the memory */
 } esp_mqtt5_event_property_t;
 

--- a/mqtt5_client.c
+++ b/mqtt5_client.c
@@ -134,6 +134,7 @@ esp_err_t esp_mqtt5_get_publish_data(esp_mqtt5_client_handle_t client, uint8_t *
     client->event.property->correlation_data_len = property.correlation_data_len;
     client->event.property->content_type = property.content_type;
     client->event.property->content_type_len = property.content_type_len;
+    client->event.property->subscribe_id = property.subscribe_id;
     return ESP_OK;
 }
 


### PR DESCRIPTION
Subscribe ID is parsed in `mqtt5_get_publish_property_payload` but isn't provided in `esp_mqtt5_event_property_t`. 

This allows applications to then build specific subscription handlers, rather than having to rely on topic filters.