### PR TITLE
fix: Allow MQTT v5 zero length payload (IDFGH-9475)

### DIFF
--- a/mqtt5_client.c
+++ b/mqtt5_client.c
@@ -101,7 +101,7 @@ esp_err_t esp_mqtt5_get_publish_data(esp_mqtt5_client_handle_t client, uint8_t *
     uint16_t property_len = 0;
     esp_mqtt5_publish_resp_property_t property = {0};
     *msg_data = mqtt5_get_publish_property_payload(msg_buf, msg_read_len, msg_topic, msg_topic_len, &property, &property_len, msg_data_len, &client->event.property->user_property);
-     if (*msg_data_len == 0 || *msg_data == NULL) {
+     if (*msg_data == NULL) {
         ESP_LOGE(TAG, "%s: mqtt5_get_publish_property_payload() failed", __func__);
         return ESP_FAIL;
     }


### PR DESCRIPTION
Zero length payload is permitted per MQTT 5 spec: 3.3.3 PUBLISH Payload (https://docs.oasis-open.org/mqtt/mqtt/v5.0/mqtt-v5.0.html#_Toc511988596).