### PR TITLE
Added support to set server common name. (IDFGH-10225)

### DIFF
--- a/include/mqtt_client.h
+++ b/include/mqtt_client.h
@@ -260,6 +260,10 @@ typedef struct esp_mqtt_client_config_t {
             bool skip_cert_common_name_check; /*!< Skip any validation of server certificate CN field, this reduces the
                                       security of TLS and makes the *MQTT* client susceptible to MITM attacks  */
             const char **alpn_protos;        /*!< NULL-terminated list of supported application protocols to be used for ALPN */
+			const char *common_name;         /*!< Pointer to the string containing server certificate common name.
+                                                               If non-NULL, server certificate CN must match this name,
+                                                               If NULL, server certificate CN must match hostname.
+                                                               This is ignored if skip_cert_common_name_check=true. */
         } verification; /*!< Security verification of the broker */
     } broker; /*!< Broker address and security verification */
     /**

--- a/include/mqtt_supported_features.h
+++ b/include/mqtt_supported_features.h
@@ -64,5 +64,11 @@
 #define MQTT_SUPPORTED_FEATURE_CERTIFICATE_BUNDLE
 #endif
 
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 0)
+// Features supported in 5.1.0
+#define MQTT_SUPPORTED_FEATURE_CRT_CMN_NAME
+#endif
+
+
 #endif /* ESP_IDF_VERSION */
 #endif // _MQTT_SUPPORTED_FEATURES_H_

--- a/lib/include/mqtt_client_priv.h
+++ b/lib/include/mqtt_client_priv.h
@@ -89,6 +89,7 @@ typedef struct {
     size_t clientkey_bytes;
     const struct psk_key_hint *psk_hint_key;
     bool skip_cert_common_name_check;
+    const char *common_name;
     bool use_secure_element;
     void *ds_data;
     int message_retransmit_timeout;

--- a/mqtt_client.c
+++ b/mqtt_client.c
@@ -181,6 +181,15 @@ static esp_err_t esp_mqtt_set_ssl_transport_properties(esp_transport_list_handle
 #endif
     }
 
+    if (cfg->common_name) {
+#if defined(MQTT_SUPPORTED_FEATURE_CRT_CMN_NAME) && MQTT_ENABLE_SSL
+        esp_transport_ssl_set_common_name(ssl, cfg->common_name);
+#else
+        ESP_LOGE(TAG, "Setting expected certificate common name is not available in IDF version %s", IDF_VER);
+        goto esp_mqtt_set_transport_failed;
+#endif
+    }
+
     if (cfg->use_secure_element) {
 #ifdef MQTT_SUPPORTED_FEATURE_SECURE_ELEMENT
 #ifdef CONFIG_ESP_TLS_USE_SECURE_ELEMENT
@@ -509,6 +518,7 @@ esp_err_t esp_mqtt_set_config(esp_mqtt_client_handle_t client, const esp_mqtt_cl
     client->config->clientkey_buf = config->credentials.authentication.key;
     client->config->clientkey_bytes = config->credentials.authentication.key_len;
     client->config->skip_cert_common_name_check = config->broker.verification.skip_cert_common_name_check;
+    client->config->common_name = config->broker.verification.common_name;
     client->config->use_secure_element = config->credentials.authentication.use_secure_element;
     client->config->ds_data = config->credentials.authentication.ds_data;
 


### PR DESCRIPTION
I would like to suggest adding the possibility to configure the server TLS certificate's expected common_name. This would allow us to connect to a server where the hostname differs from the CN of the server certificate, or if DNS is not available and we connect via IP address but know the server's hostname/CN.

For example, if both a server's hostname and its CN is `server`, but we can't resolve its hostname via DNS and connect via `.uri =  "mqtts://192.168.2.123"` we get a TLS error and connection failure. If we can manually set the expected CN to `server` the connection succeeds. Setting `skip_cert_common_name_check=true` works too but reduces security.

This has already been [implemented for the http_client](https://github.com/espressif/esp-idf/commit/4904d57fd98a787e41c268cfa19f590a0607b3c9). This pull request does exactly the same thing for MQTT. This requires using the function `esp_transport_ssl_set_common_name`, which has been [added](https://github.com/espressif/esp-idf/commit/ce321837497bb701d22d3aaf3fcd8e26e310d21f) on IDF master. Therefore, the pull request checks for IDF version `v5.1.0` for enabling the feature.

I added a field `common_name` for `esp_mqtt_client_config_t::broker.verification`. If it is not `NULL`, it will be passed to `esp_transport_ssl_set_common_name`, analog to `skip_cert_common_name_check` and `esp_transport_ssl_skip_common_name_check`.

Usage is:

```c
esp_mqtt_client_config_t {
	.broker = {
		.address = {
			 .uri =  "mqtts://192.168.2.123" // If the server doesn't have a DNS entry, we can't pass "mqtts://server" but have to use the IP address
		},
		.verification = {
			.skip_cert_common_name_check = false, // We want to avoid setting this to true
			.common_name = "server"
		}
	},
```

If `common_name` is set to `NULL`, behavior is as before (API backwards compatible).

Thanks for looking into this!