### PR TITLE
Fix Jira sync action (IDFGH-10224)

### DIFF
--- a/.github/workflows/new_prs.yml
+++ b/.github/workflows/new_prs.yml
@@ -1,16 +1,25 @@
-name: Sync PRs to JIRA
+name: Sync remain PRs to Jira
 
-# This workflow will be triggered when a pull request is opened
-on: pull_request
+# This workflow will be triggered every hour, to sync remaining PRs (i.e. PRs with zero comment) to Jira project
+# Note that, PRs can also get synced when new PR comment is created
+on:
+  schedule:
+    - cron: "0 * * * *"
+
+# Limit to single concurrent run for workflows which can create Jira issues.
+# Same concurrency group is used in issue_comment.yml
+concurrency: jira_issues
 
 jobs:
   sync_prs_to_jira:
     name: Sync PRs to Jira
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - name: Sync PRs to Jira project
         uses: espressif/github-actions/sync_issues_to_jira@master
+        with:
+          cron_job: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JIRA_PASS: ${{ secrets.JIRA_PASS }}


### PR DESCRIPTION
The GitHub action to synchronize pull requests to JIRA has been failing for a long time: 
- example: https://github.com/espressif/esp-mqtt/actions/runs/5068380137/jobs/9101872544
- history of failed jobs: https://github.com/espressif/esp-mqtt/actions/workflows/new_prs.yml

I tried to set it up the same way as it is set up in other repositories (e.g. `espressif/esp-idf`) and it seems to work, see.: https://github.com/espressif/esp-mqtt/actions/runs/5069104172/jobs/9102251445?pr=259#step:4:13

I suggest setting this action to be triggered by cron every hour, instead of the current setting of triggering when a download request is sent.