### PR TITLE
mqtt: allow using external TCP transport handles (IDFGH-10290)

### DIFF
--- a/include/mqtt_client.h
+++ b/include/mqtt_client.h
@@ -10,6 +10,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <string.h>
+#include <esp_transport.h>
 #include "esp_err.h"
 #include "esp_event.h"
 #ifdef CONFIG_MQTT_PROTOCOL_5
@@ -347,6 +348,7 @@ typedef struct esp_mqtt_client_config_t {
         int out_size; /*!< size of *MQTT* output buffer. If not defined, defaults to the size defined by
               ``buffer_size`` */
     } buffer; /*!< Buffer size configuration.*/
+    esp_transport_handle_t ext_transport; /*!< External tcp_transport handle to the client, e.g. proxy; or if null, the client will create its own transport handle. */
 } esp_mqtt_client_config_t;
 
 /**

--- a/lib/include/mqtt_client_priv.h
+++ b/lib/include/mqtt_client_priv.h
@@ -91,6 +91,7 @@ typedef struct {
     bool use_secure_element;
     void *ds_data;
     int message_retransmit_timeout;
+    esp_transport_handle_t ext_transport;
 } mqtt_config_storage_t;
 
 typedef enum {


### PR DESCRIPTION
Hi there,

This PR is to add support for external TCP transport handles, e.g. the SOCKS proxy, or my [HTTP/HTTPS proxy](https://github.com/huming2207/esp-tcp-transport-http-proxy).

See here for more details: https://github.com/espressif/esp-idf/issues/10684

Regards,
Jackson