### PR TITLE
Free certs (IDFGH-10667)

### DIFF
--- a/mqtt_client.c
+++ b/mqtt_client.c
@@ -609,6 +609,9 @@ void esp_mqtt_destroy_config(esp_mqtt_client_handle_t client)
     free(client->config->alpn_protos);
     free(client->config->clientkey_password);
     free(client->config->if_name);
+    free(client->config->cacert_buf);
+    free(client->config->clientkey_buf);
+    free(client->config->clientcert_buf);
     free(client->mqtt_state.connection.information.will_topic);
     free(client->mqtt_state.connection.information.will_message);
     free(client->mqtt_state.connection.information.client_id);


### PR DESCRIPTION
In the `esp_mqtt_destroy_config function`, MQTT certificates are not freed.