### PR TITLE
Update esp_mqtt_client_subscribe() macros

### DIFF
--- a/include/mqtt_client.h
+++ b/include/mqtt_client.h
@@ -463,6 +463,7 @@ esp_err_t esp_mqtt_client_stop(esp_mqtt_client_handle_t client);
  */
 #define esp_mqtt_client_subscribe(client_handle, topic_type, qos_or_size) _Generic((topic_type), \
       char *: esp_mqtt_client_subscribe_single, \
+      const char *: esp_mqtt_client_subscribe_single, \
       esp_mqtt_topic_t*: esp_mqtt_client_subscribe_multiple \
     )(client_handle, topic_type, qos_or_size)
 


### PR DESCRIPTION
Change "char *" to "const char *"  in esp_mqtt_client_subscribe generic macros. Without these changes, functions passing "const char *" are not compiled

```
/home/fl/esp/idfmaster/components/mqtt/esp-mqtt/include/mqtt_client.h:464:84: error: '_Generic' selector of type 'const char *' is not compatible with any association
  464 | #define esp_mqtt_client_subscribe(client_handle, topic_type, qos_or_size) _Generic((topic_type), \
      |                                                                                    ^
```