### PR TITLE
Suppress error in snprintf with a pointer variable (IDFGH-12441)

### DIFF
--- a/lib/mqtt5_msg.c
+++ b/lib/mqtt5_msg.c
@@ -763,7 +763,9 @@ mqtt_message_t *mqtt5_msg_publish(mqtt_connection_t *connection, const char *top
                     ESP_LOGE(TAG, "Failed to calloc %d memory", response_topic_size);
                     fail_message(connection);
                 }
-                snprintf(response_topic, response_topic_size, "%s/%s", property->response_topic, resp_info);
+                if (response_topic) { // makes the compiler happy
+                    snprintf(response_topic, response_topic_size, "%s/%s", property->response_topic, resp_info);
+                }
                 if (append_property(connection, MQTT5_PROPERTY_RESPONSE_TOPIC, 2, response_topic, response_topic_size) == -1) {
                     ESP_LOGE(TAG, "%s(%d) fail", __FUNCTION__, __LINE__);
                     free(response_topic);


### PR DESCRIPTION
Suppresses the following error:
lib/mqtt5_msg.c:767:17: error: null destination pointer [-Werror=format-truncation=]
  767 |                 snprintf(response_topic, response_topic_size, "%s/%s", property->response_topic, resp_info);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~