### PR TITLE
fix: set TCP transport every time when setting the config (IDFGH-13175)

### DIFF
--- a/include/mqtt_client.h
+++ b/include/mqtt_client.h
@@ -336,7 +336,7 @@ typedef struct esp_mqtt_client_config_t {
         int refresh_connection_after_ms; /*!< Refresh connection after this value (in milliseconds) */
         bool disable_auto_reconnect;     /*!< Client will reconnect to server (when errors/disconnect). Set
                                  `disable_auto_reconnect=true` to disable */
-        esp_transport_handle_t transport; /*!< Custom transport handle to use. Warning: The transport should be valid during the client lifetime and is destroyed when esp_mqtt_client_destroy is called. */
+        esp_transport_handle_t transport; /*!< Custom transport handle to use, leave it NULL to allow MQTT client create or recreate its own. Warning: The transport should be valid during the client lifetime and is destroyed when esp_mqtt_client_destroy is called. */
         struct ifreq * if_name; /*!< The name of interface for data to go through. Use the default interface without setting */
     } network; /*!< Network configuration */
     /**

--- a/mqtt_client.c
+++ b/mqtt_client.c
@@ -526,9 +526,8 @@ esp_err_t esp_mqtt_set_config(esp_mqtt_client_handle_t client, const esp_mqtt_cl
     } else {
         client->config->reconnect_timeout_ms = MQTT_RECON_DEFAULT_MS;
     }
-    if (config->network.transport) {
-        client->config->transport = config->network.transport;
-    }
+    
+    client->config->transport = config->network.transport;
 
     if (config->network.if_name) {
         client->config->if_name = calloc(1, sizeof(struct ifreq) + 1);


### PR DESCRIPTION
Hi @gabsuren @euripedesrocha 

We just realised that the TCP transport is not set every time. When the incoming `config::network::transport` handle is null, it will not be set, and the MQTT client will keep using the previous old (invalid) TCP transport handle.

This is a bit problematic for us. One of our products have a few network interfaces. For example, when using WiFi, the MQTT (over WebSocket) client requires our own TCP transport handle with HTTP proxy, but 4G modem doesn't. When a switchover is needed, we would call `esp_mqtt_client_disconnect` to disconnect, and then call `esp_mqtt_set_config()` to reconfigure the client to let it start using or stop using a the TCP transport with proxy. 

But now in current implementation, since you have a `if (config->network.transport)` null check, this will prevent us from clearing the TCP transport setting. Therefore I think we need to remove this unnecessary null check. 

Regards,
Jackson