### PR TITLE
When MQTT_REPORT_DELETED_MESSAGES, delete QOS messages with id 0 (IDFGH-14022)

### DIFF
--- a/mqtt_client.c
+++ b/mqtt_client.c
@@ -1544,7 +1544,7 @@ static void mqtt_delete_expired_messages(esp_mqtt_client_handle_t client)
 #if MQTT_REPORT_DELETED_MESSAGES
     // also report the deleted items as MQTT_EVENT_DELETED events if enabled
     int msg_id = 0;
-    while ((msg_id = outbox_delete_single_expired(client->outbox, platform_tick_get_ms(), OUTBOX_EXPIRED_TIMEOUT_MS)) > 0) {
+    while ((msg_id = outbox_delete_single_expired(client->outbox, platform_tick_get_ms(), OUTBOX_EXPIRED_TIMEOUT_MS)) >= 0) {
         client->event.event_id = MQTT_EVENT_DELETED;
         client->event.msg_id = msg_id;
         if (esp_mqtt_dispatch_event(client) != ESP_OK) {


### PR DESCRIPTION
## Description
Fixes #289 
When my outbox has only QOS0 messages, I receive no MQTT_EVENT_DELETED posted to the event handler, and only the first message in the outbox is deleted if it has been in the outbox > OUTBOX_EXPIRED_TIMEOUT_MS.

This is because QOS0 messages are given a msg_id of 0 and mqtt_delete_expired_messages stops deleting outbox items once their msg_id is 0.

This change allows messages with ids of 0 to be deleted as well.

## Testing

Tested as described in the github issue.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
