### PR TITLE
Add the parsing of DISCONNECT packet for MQTT 5 (IDFGH-14489)

### DIFF
--- a/include/mqtt5_client.h
+++ b/include/mqtt5_client.h
@@ -18,7 +18,7 @@ typedef struct esp_mqtt_client *esp_mqtt5_client_handle_t;
 /**
  *  MQTT5 protocol error reason code, more details refer to MQTT5 protocol document section 2.4
  */
-enum mqtt5_error_reason_code {
+typedef enum mqtt5_error_reason_code_t {
     MQTT5_UNSPECIFIED_ERROR                                   = 0x80,
     MQTT5_MALFORMED_PACKET                                    = 0x81,
     MQTT5_PROTOCOL_ERROR                                      = 0x82,
@@ -59,7 +59,7 @@ enum mqtt5_error_reason_code {
     MQTT5_MAXIMUM_CONNECT_TIME                                = 0xA0,
     MQTT5_SUBSCRIBE_IDENTIFIER_NOT_SUPPORT                    = 0xA1,
     MQTT5_WILDCARD_SUBSCRIBE_NOT_SUPPORT                      = 0xA2,
-};
+} esp_mqtt5_error_reason_code_t;
 
 /**
  *  MQTT5 user property handle

--- a/include/mqtt_client.h
+++ b/include/mqtt_client.h
@@ -182,6 +182,11 @@ typedef struct esp_mqtt_error_codes {
     esp_mqtt_connect_return_code_t
     connect_return_code; /*!< connection refused error code reported from
                               *MQTT* broker on connection */
+#ifdef CONFIG_MQTT_PROTOCOL_5
+    esp_mqtt5_error_reason_code_t
+    disconnect_return_code; /*!< disconnection reason code reported from
+                              *MQTT* broker on disconnection */
+#endif
     /* tcp_transport extension */
     int esp_transport_sock_errno; /*!< errno from the underlying socket */
 

--- a/lib/include/mqtt5_client_priv.h
+++ b/lib/include/mqtt5_client_priv.h
@@ -42,6 +42,7 @@ void esp_mqtt5_parse_pubcomp(esp_mqtt5_client_handle_t client);
 void esp_mqtt5_parse_puback(esp_mqtt5_client_handle_t client);
 void esp_mqtt5_parse_unsuback(esp_mqtt5_client_handle_t client);
 void esp_mqtt5_parse_suback(esp_mqtt5_client_handle_t client);
+void esp_mqtt5_parse_disconnect(esp_mqtt5_client_handle_t client, int *disconnect_rsp_code);
 esp_err_t esp_mqtt5_parse_connack(esp_mqtt5_client_handle_t client, int *connect_rsp_code);
 void esp_mqtt5_client_destory(esp_mqtt5_client_handle_t client);
 esp_err_t esp_mqtt5_client_publish_check(esp_mqtt5_client_handle_t client, int qos, int retain);

--- a/mqtt5_client.c
+++ b/mqtt5_client.c
@@ -76,6 +76,14 @@ void esp_mqtt5_parse_suback(esp_mqtt5_client_handle_t client)
     }
 }
 
+void esp_mqtt5_parse_disconnect(esp_mqtt5_client_handle_t client, int *disconnect_rsp_code)
+{
+    if (client->mqtt_state.connection.information.protocol_ver == MQTT_PROTOCOL_V_5) {
+        *disconnect_rsp_code = mqtt5_msg_get_reason_code(client->mqtt_state.in_buffer, client->mqtt_state.in_buffer_read_len);
+        ESP_LOGD(TAG, "MQTT_MSG_TYPE_DISCONNECT return code is %d", *disconnect_rsp_code);
+    }
+}
+
 esp_err_t esp_mqtt5_parse_connack(esp_mqtt5_client_handle_t client, int *connect_rsp_code)
 {
     size_t len = client->mqtt_state.in_buffer_read_len;


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

In the MQTT 5 protocol the broker can disconnect the client with a DISCONNECT packet. This packet contains the reason code of the forced disconnection.
Before these patches the DISCONNECT packet was not parsed and it was not possible to know and check the disconnection reason by the broker at application level.

So now in mqtt_process_receive also the disconnect packets are processed, setting the disconnect_return_code variable in the error_handle structure (as per the connect_return_code) and sending the event to the application event loop.

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->
I tested it with a mqtt 5 server and 2 ESP32-S3-WROOM-1-N16R8V modules. 
When the two modules were connected to the broker with same client ID, the first one was kicked out (as per specification). I wanted to have the reason code of the DISCONNECT packet so if it was 0x8E (MQTT5_SESSION_TAKEN_OVER),  the first client is not continuing reconnecting in my application (it was creating a loop of connection and disconnection between the first and the second client). 
I found this solutions, but I am open to suggestion! Thanks!

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
