### PR TITLE
feat(mqtt): enable custom TLS cipher suites for MQTTs (IDFGH-15198)

### DIFF
--- a/include/mqtt_client.h
+++ b/include/mqtt_client.h
@@ -264,6 +264,8 @@ typedef struct esp_mqtt_client_config_t {
                                                                If NULL, server certificate CN must match hostname.
                                                                This is ignored if skip_cert_common_name_check=true.
                                                   It's not copied nor freed by the client, user needs to clean up.*/
+            const int *ciphersuites_list;    /*!< Pointer to a zero-terminated array of IANA identifiers of TLS cipher suites. 
+                                              Please ensure the validity of the list, and note that it is not copied or freed by the client. */
         } verification; /*!< Security verification of the broker */
     } broker; /*!< Broker address and security verification */
     /**

--- a/lib/include/mqtt_client_priv.h
+++ b/lib/include/mqtt_client_priv.h
@@ -85,6 +85,7 @@ typedef struct {
     int clientkey_password_len;
     bool use_global_ca_store;
     esp_err_t ((*crt_bundle_attach)(void *conf));
+    const int *ciphersuites_list;
     const char *cacert_buf;
     size_t cacert_bytes;
     const char *clientcert_buf;

--- a/mqtt_client.c
+++ b/mqtt_client.c
@@ -162,6 +162,12 @@ static esp_err_t esp_mqtt_set_ssl_transport_properties(esp_transport_list_handle
                      goto esp_mqtt_set_transport_failed);
 
     }
+
+    if(cfg->ciphersuites_list)
+    {
+        esp_transport_ssl_set_ciphersuites_list(ssl,cfg->ciphersuites_list);
+    }
+
     if (cfg->psk_hint_key) {
 #if defined(MQTT_SUPPORTED_FEATURE_PSK_AUTHENTICATION) && MQTT_ENABLE_SSL
 #ifdef CONFIG_ESP_TLS_PSK_VERIFICATION
@@ -564,6 +570,7 @@ esp_err_t esp_mqtt_set_config(esp_mqtt_client_handle_t client, const esp_mqtt_cl
     client->config->cacert_bytes = config->broker.verification.certificate_len;
     client->config->psk_hint_key = config->broker.verification.psk_hint_key;
     client->config->crt_bundle_attach = config->broker.verification.crt_bundle_attach;
+    client->config->ciphersuites_list = config->broker.verification.ciphersuites_list;
     client->config->clientcert_buf = config->credentials.authentication.certificate;
     client->config->clientcert_bytes = config->credentials.authentication.certificate_len;
     client->config->clientkey_buf = config->credentials.authentication.key;


### PR DESCRIPTION
## Description

- Add `ciphersuites_list` to `esp_mqtt_client_config_t` for specifying TLS cipher suites.
- Update SSL transport configuration to use the provided cipher suites.
- Users are responsible for managing the cipher suites list memory.

This change allows users to flexibly select the TLS cipher suites used in MQTT communication, improving the ability to meet increasingly stringent network security certifications. By adding the `ciphersuites_list` to `esp_mqtt_client_config_t`, users now have full control over the encryption suites used in the connection, which enhances security and adaptability in various environments.

The provided cipher suite list is not copied or freed by the client, so users are responsible for managing the memory of the list.

## Related

Dependent on this submitted change

https://github.com/espressif/esp-idf/pull/15868

## Testing

Tested by configuring the specified TLS cipher suites in the MQTT client configuration and using Wireshark to capture the packets during the TLS handshake. The captured packets were analyzed to verify that the selected cipher suites were indeed used in the communication. This method confirmed the configuration's effectiveness on ESP32-S3 with a secure MQTT broker.



``` c
const int ETSI_EN_303645_ciphersuites_list[] = {
    MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
    MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
    MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_256_CCM,
    MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_CCM,
    MBEDTLS_TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
    MBEDTLS_TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
    0
};

esp_mqtt_client_config_t mqtt_cfg = {
    .broker.address.uri = mqtt_config.broker_uri,
    .credentials.client_id = mqtt_config.client_id,
    .credentials.username = mqtt_config.username,
    .credentials.authentication.password = mqtt_config.password,
    .session.keepalive=atoi(mqtt_config.keepalive),
    .network.timeout_ms=5000,
    .broker.verification.crt_bundle_attach = esp_crt_bundle_attach,
    .broker.verification.ciphersuites_list = ETSI_EN_303645_ciphersuites_list,
};
```

![image](https://github.com/user-attachments/assets/873290fc-794a-4262-9626-5b710792175e)


