### PR TITLE
fix: subscribe/unsubscribe message ID race condition (IDFGH-16024)

### DIFF
--- a/mqtt_client.c
+++ b/mqtt_client.c
@@ -1946,8 +1946,10 @@ int esp_mqtt_client_subscribe_multiple(esp_mqtt_client_handle_t client,
     }
 
     ESP_LOGD(TAG, "Sent subscribe, first topic=%s, id: %d", topic_list[0].filter, client->mqtt_state.pending_msg_id);
+
+    int pending_msg_id = client->mqtt_state.pending_msg_id;
     MQTT_API_UNLOCK(client);
-    return client->mqtt_state.pending_msg_id;
+    return pending_msg_id;
 
 }
 int esp_mqtt_client_subscribe_single(esp_mqtt_client_handle_t client, const char *topic, int qos)
@@ -2002,8 +2004,10 @@ int esp_mqtt_client_unsubscribe(esp_mqtt_client_handle_t client, const char *top
     }
 
     ESP_LOGD(TAG, "Sent Unsubscribe topic=%s, id: %d, successful", topic, client->mqtt_state.pending_msg_id);
+
+    int pending_msg_id = client->mqtt_state.pending_msg_id;
     MQTT_API_UNLOCK(client);
-    return client->mqtt_state.pending_msg_id;
+    return pending_msg_id;
 }
 
 static int make_publish(esp_mqtt_client_handle_t client, const char *topic, const char *data,


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

I've noticed a subtle race condition in the returned message IDs when using `esp_mqtt_client_subscribe_multiple()` and `esp_mqtt_client_unsubscribe()`:
- Both return the message ID to the caller via `return client->mqtt_state.pending_msg_id`, i.e., a pointer
- This return occurs after the API is unlocked via `MQTT_API_UNLOCK(client)`
- If multiple threads are using the client, then this return value could possibly be altered by another API call in the following manner:
    1. Return value is intended to be `client->mqtt_state.pending_msg_id = 4` (for example), and call unlocks.
    2. Context switch occurs before return happens.
    3. Another API call modifies `client->mqtt_state.pending_msg_id = 5`. (e.g., in the incremental case)
    4. Context switches back to original call, which now returns the wrong value of 5, even though the MQTT message was sent with message ID 4. 

This makes it possible for two API calls to return the same message ID when called at approximately the same time, with one API call losing access to its actual message ID, which can disrupt use cases where the message ID is required to be unique (at least for messages in close temporal proximity), or for use cases where future actions are dependent on the message ID (e.g., callbacks).

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->
1. Set the `MQTT_MSG_ID_INCREMENTAL` config.
2. Create a FreeRTOS task function that uses `esp_mqtt_client_subscribe()` / `esp_mqtt_client_unsubscribe()`, and logs the message ID received.
3. Use `xTaskCreate()` to create multiple instances of the same task function.
4. Observe any message ID duplicates.

If an event handler is also registered using `esp_mqtt_client_register_event()`, then the 'lost' message IDs can be compared by printing `event_data->msg_id` for `MQTT_EVENT_SUBSCRIBED` / `MQTT_EVENT_UNSUBSCRIBED` events, i.e., seeing something like:

```
esp_mqtt_client_subscribe() message ID: 1
esp_mqtt_client_subscribe() message ID: 2
MQTT_EVENT_SUBSCRIBED message ID: 1
esp_mqtt_client_subscribe() message ID: 4 // this was supposed to be '3', but was overwritten
esp_mqtt_client_subscribe() message ID: 4
MQTT_EVENT_SUBSCRIBED message ID: 2
MQTT_EVENT_SUBSCRIBED message ID: 3 // this is the 'lost' message ID
MQTT_EVENT_SUBSCRIBED message ID: 4
```
