### PR TITLE
fix: remove in_buffer_length constraint on maximum_packet_size (IDFGH-17162)

### DIFF
--- a/mqtt5_client.c
+++ b/mqtt5_client.c
@@ -667,14 +667,7 @@ esp_err_t esp_mqtt5_client_set_connect_property(esp_mqtt5_client_handle_t client
         }
 
         if (connect_property->maximum_packet_size) {
-            if (connect_property->maximum_packet_size > client->mqtt_state.in_buffer_length) {
-                ESP_LOGW(TAG, "Connect maximum_packet_size property is over buffer_size(%d), Please first change it",
-                         client->mqtt_state.in_buffer_length);
-                MQTT_API_UNLOCK(client);
-                return ESP_FAIL;
-            } else {
-                client->mqtt5_config->connect_property_info.maximum_packet_size = connect_property->maximum_packet_size;
-            }
+            client->mqtt5_config->connect_property_info.maximum_packet_size = connect_property->maximum_packet_size;
         } else {
             client->mqtt5_config->connect_property_info.maximum_packet_size = client->mqtt_state.in_buffer_length;
         }


### PR DESCRIPTION
## Description
Removes the artificial limit on `esp_mqtt5_connection_property_config_t.maximum_packet_size` based on `esp_mqtt_client_config_t.buffer.size`

maximum_packet_size should be unlimited, as large incoming messages (larger than `esp_mqtt_client_config_t.buffer.size`) are read in chunks and for each chunk a MQTT_EVENT_DATA callback is triggered to process data on application level  as defined in the ESP docs:

> The client has received a publish message. The event data contains: message ID, name of the topic it was published to, received data and its length. For data that exceeds the internal buffer, multiple MQTT_EVENT_DATA events are posted and [current_data_offset](https://docs.espressif.com/projects/esp-idf/en/v5.3.4/esp32/api-reference/protocols/mqtt.html#_CPPv4N16esp_mqtt_event_t19current_data_offsetE) and [total_data_len](https://docs.espressif.com/projects/esp-idf/en/v5.3.4/esp32/api-reference/protocols/mqtt.html#_CPPv4N16esp_mqtt_event_t14total_data_lenE) from event data updated to keep track of the fragmented message.
  
The existing code already handles the maximum buffer size correctly:
```
int ret = esp_transport_read(client->transport, (char *)client->mqtt_state.in_buffer,
                                         msg_total_len - msg_read_len > buf_len ? buf_len : msg_total_len - msg_read_len,
                                         client->config->network_timeout_ms);
```

Without the fix, brokers (such as Mosquitto) will drop messages larger than buffer.size:
> Dropping too large outgoing PUBLISH for esp32 (16563 bytes)

## Related
Fixes #319 - https://github.com/espressif/esp-mqtt/issues/319

## Testing

Using IDF 5.3.4 on ESP32-S3

```
static const esp_mqtt5_connection_property_config_t connect_property = 
{
  .maximum_packet_size = 2*1024*1024, // 2 MB
  .session_expiry_interval = 604800, 
};

mqtt_cfg.buffer.size                                      = 4096;
```

```
D (105350) mqtt_client: mqtt_message_receive: first byte: 0x30
D (105350) mqtt_client: mqtt_message_receive: read "remaining length" byte: 0xb0
D (105350) mqtt_client: mqtt_message_receive: read "remaining length" byte: 0x81
D (105350) mqtt_client: mqtt_message_receive: read "remaining length" byte: 0x4
D (105350) mqtt_client: mqtt_message_receive: total message length: 65716 (already read: 4)
D (105350) mqtt_client: mqtt_message_receive: read_len=2
D (105351) mqtt_client: mqtt_message_receive: total len modified to 38 as message longer than input buffer
D (105351) mqtt_client: mqtt_message_receive: read_len=4090
D (105351) mqtt_client: msg_type=3, msg_id=0
D (105351) mqtt_client: deliver_publish, message_length_read=4096, message_length=65716
D (105352) mqtt_client: Get data len= 3912, topic len=34, total_data: 65532 offset: 0
I (105352) MQTTClient: MQTT_EVENT_DATA
I (105353) DataParser: Receiving long message (65532 bytes)
D (105354) mqtt_client: Get data len= 4096, topic len=0, total_data: 65532 offset: 3912
I (105354) MQTTClient: MQTT_EVENT_DATA
D (105354) mqtt_client: Get data len= 4096, topic len=0, total_data: 65532 offset: 8008
I (105354) MQTTClient: MQTT_EVENT_DATA
D (105355) mqtt_client: Get data len= 4096, topic len=0, total_data: 65532 offset: 12104
I (105355) MQTTClient: MQTT_EVENT_DATA
D (105383) mqtt_client: Get data len= 4096, topic len=0, total_data: 65532 offset: 16200
I (105384) MQTTClient: MQTT_EVENT_DATA
D (105384) mqtt_client: Get data len= 4096, topic len=0, total_data: 65532 offset: 20296
I (105384) MQTTClient: MQTT_EVENT_DATA
D (105385) mqtt_client: Get data len= 4096, topic len=0, total_data: 65532 offset: 24392
I (105385) MQTTClient: MQTT_EVENT_DATA
D (105386) mqtt_client: Get data len= 4096, topic len=0, total_data: 65532 offset: 28488
I (105386) MQTTClient: MQTT_EVENT_DATA
D (105416) mqtt_client: Get data len= 4096, topic len=0, total_data: 65532 offset: 32584
I (105416) MQTTClient: MQTT_EVENT_DATA
D (105417) mqtt_client: Get data len= 4096, topic len=0, total_data: 65532 offset: 36680
I (105417) MQTTClient: MQTT_EVENT_DATA
D (105417) mqtt_client: Get data len= 4096, topic len=0, total_data: 65532 offset: 40776
I (105418) MQTTClient: MQTT_EVENT_DATA
D (105418) mqtt_client: Get data len= 4096, topic len=0, total_data: 65532 offset: 44872
I (105418) MQTTClient: MQTT_EVENT_DATA
D (105445) mqtt_client: Get data len= 4096, topic len=0, total_data: 65532 offset: 48968
I (105446) MQTTClient: MQTT_EVENT_DATA
D (105446) mqtt_client: Get data len= 4096, topic len=0, total_data: 65532 offset: 53064
I (105446) MQTTClient: MQTT_EVENT_DATA
D (105447) mqtt_client: Get data len= 4096, topic len=0, total_data: 65532 offset: 57160
I (105447) MQTTClient: MQTT_EVENT_DATA
D (105448) mqtt_client: Get data len= 4096, topic len=0, total_data: 65532 offset: 61256
I (105448) MQTTClient: MQTT_EVENT_DATA
D (105450) mqtt_client: Get data len= 180, topic len=0, total_data: 65532 offset: 65352
I (105450) MQTTClient: MQTT_EVENT_DATA
```

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X ] 🚨 This PR does not introduce breaking changes.
- [ X] All CI checks (GH Actions) pass.
- [X ] Documentation is updated as needed. (not needed)
- [X ] Tests are updated or added as necessary.
- [ X] Code is well-commented, especially in complex areas.
- [ X] Git history is clean — commits are squashed to the minimum necessary.
