### PR TITLE
fix(mqtt_msg): fix signed integer overflow in remaining length decoding (IDFGH-17231)

### DIFF
--- a/lib/mqtt_msg.c
+++ b/lib/mqtt_msg.c
@@ -121,9 +121,8 @@ size_t mqtt_get_total_length(const uint8_t *buffer, size_t length, int *fixed_si
     int i;
     size_t totlen = 0;
 
-    for (i = 1; i < length; ++i) {
-        totlen += (buffer[i] & 0x7f) << (7 * (i - 1));
-
+    for (i = 1; i < length && i <= 4; ++i) {
+        totlen += (size_t)(buffer[i] & 0x7f) << (7 * (i - 1));
         if ((buffer[i] & 0x80) == 0) {
             ++i;
             break;
@@ -208,7 +207,7 @@ char *mqtt_get_publish_data(uint8_t *buffer, size_t *length)
     int blength = *length;
     *length = 0;
 
-    for (i = 1; i < blength; ++i) {
+    for (i = 1; i < blength && i <= 4; ++i) {
         totlen += (buffer[i] & 0x7f) << (7 * (i - 1));
 
         if ((buffer[i] & 0x80) == 0) {


### PR DESCRIPTION
## Summary

Fix undefined behavior (signed integer overflow) in the MQTT remaining length decoding loop in `mqtt_get_total_length()` and `mqtt_get_publish_data()` (`lib/mqtt_msg.c`).

The expression `(buffer[i] & 0x7f) << (7 * (i - 1))` performs a left shift on a signed `int`. When `i >= 5`, the shift amount reaches 28+, and `0x7f << 28` (= 34,091,302,912) overflows `INT_MAX`, which is undefined behavior per C11 §6.5.7.

Per MQTT 3.1.1 §2.2.3, the Remaining Length field uses **at most 4 continuation bytes**, so `i` should never exceed 4.

### Changes

- **`mqtt_get_total_length()`**: cast to `size_t` before shifting (totlen is already `size_t`) + limit loop to `i <= 4`
- **`mqtt_get_publish_data()`**: limit loop to `i <= 4` (max shift = 21, safe for `int`)

### Details

- **Functions**: `mqtt_get_total_length()`, `mqtt_get_publish_data()` in `lib/mqtt_msg.c`
- **Root cause**: unbounded loop allows `i` to reach 5+, causing shift overflow
- **Impact**: undefined behavior when parsing crafted MQTT packets with >4 remaining-length bytes
- **Found via**: coverage-guided fuzzing (libFuzzer + UndefinedBehaviorSanitizer)

### Reproducer

```
echo -ne '\xff\xfb\xff\xff\xff\xff' > crash.bin
# Feed to any code path calling mqtt_get_total_length()
```