### PR TITLE
feat(mqtt5): add per-message publish/subscribe/unsubscribe property APIs (IDFGH-18158)

### DIFF
--- a/include/mqtt_client.h
+++ b/include/mqtt_client.h
@@ -530,9 +530,19 @@ int esp_mqtt_client_subscribe_single(esp_mqtt_client_handle_t client,
  *
  * Same behavior as `esp_mqtt_client_subscribe_single`, but the subscribe
  * properties (including user properties) passed in `property` are applied
- * directly to this message atomically. Properties set via
- * `esp_mqtt5_client_set_subscribe_property` still apply as a base for this
- * message, and any field present in `property` overrides it.
+ * directly to this message atomically, so no separate
+ * `esp_mqtt5_client_set_subscribe_property` call is required and it is safe to
+ * call from multiple tasks.
+ *
+ * A non-NULL `property` is used *instead of* anything staged via
+ * `esp_mqtt5_client_set_subscribe_property` — the two are not merged, and the
+ * staged property is left in place for the next plain subscribe. Passing NULL
+ * falls back to the staged property (and consumes it) exactly like
+ * `esp_mqtt_client_subscribe_single`.
+ *
+ * `property` is validated the same way `esp_mqtt5_client_set_subscribe_property`
+ * validates it (shared-subscription rules, `retain_handle` range); an invalid
+ * property is rejected instead of being put on the wire.
  *
  * @param client    *MQTT* client handle
  * @param topic topic filter to subscribe
@@ -541,7 +551,7 @@ int esp_mqtt_client_subscribe_single(esp_mqtt_client_handle_t client,
  * properties set via `esp_mqtt5_client_set_subscribe_property`
  *
  * @return message_id of the subscribe message on success
- *         -1 on failure
+ *         -1 on failure, including an invalid `property`
  *         -2 in case of full outbox.
  */
 int esp_mqtt_client_subscribe5(esp_mqtt_client_handle_t client,
@@ -593,17 +603,27 @@ int esp_mqtt_client_unsubscribe(esp_mqtt_client_handle_t client,
  *
  * Same behavior as `esp_mqtt_client_unsubscribe`, but the unsubscribe
  * properties (including user properties) passed in `property` are applied
- * directly to this message atomically. Properties set via
- * `esp_mqtt5_client_set_unsubscribe_property` still apply as a base for this
- * message, and any field present in `property` overrides it.
+ * directly to this message atomically, so no separate
+ * `esp_mqtt5_client_set_unsubscribe_property` call is required and it is safe to
+ * call from multiple tasks.
+ *
+ * A non-NULL `property` is used *instead of* anything staged via
+ * `esp_mqtt5_client_set_unsubscribe_property` — the two are not merged, and the
+ * staged property is left in place for the next plain unsubscribe. Passing NULL
+ * falls back to the staged property (and consumes it) exactly like
+ * `esp_mqtt_client_unsubscribe`.
+ *
+ * `property` is validated the same way `esp_mqtt5_client_set_unsubscribe_property`
+ * validates it (shared-subscription rules); an invalid property is rejected
+ * instead of being put on the wire.
  *
  * @param client    *MQTT* client handle
  * @param topic
  * @param property  unsubscribe properties for this message, may be NULL to use
  * the properties set via `esp_mqtt5_client_set_unsubscribe_property`
  *
- * @return message_id of the subscribe message on success
- *         -1 on failure
+ * @return message_id of the unsubscribe message on success
+ *         -1 on failure, including an invalid `property`
  */
 int esp_mqtt_client_unsubscribe5(esp_mqtt_client_handle_t client,
                                  const char *topic,
@@ -649,10 +669,18 @@ int esp_mqtt_client_publish(esp_mqtt_client_handle_t client, const char *topic,
  *
  * Same behavior as `esp_mqtt_client_publish`, but the publish properties
  * (including user properties) passed in `property` are applied directly to this
- * message atomically (no separate `esp_mqtt5_client_set_publish_property` call
- * is required, so it is safe to call from multiple tasks). Properties set via
- * `esp_mqtt5_client_set_publish_property` still apply as a base for this
- * message, and any field present in `property` overrides it.
+ * message atomically, so no separate `esp_mqtt5_client_set_publish_property`
+ * call is required and it is safe to call from multiple tasks.
+ *
+ * A non-NULL `property` is used *instead of* anything staged via
+ * `esp_mqtt5_client_set_publish_property` — the two are not merged, and the
+ * staged property is left in place for the next plain publish. Passing NULL
+ * falls back to the staged property (and consumes it) exactly like
+ * `esp_mqtt_client_publish`.
+ *
+ * `property` is validated the same way `esp_mqtt5_client_set_publish_property`
+ * validates it (`topic_alias` against the server maximum); an invalid property
+ * is rejected instead of being put on the wire.
  *
  * @param client    *MQTT* client handle
  * @param topic     topic string
@@ -665,7 +693,8 @@ int esp_mqtt_client_publish(esp_mqtt_client_handle_t client, const char *topic,
  * properties set via `esp_mqtt5_client_set_publish_property`
  *
  * @return message_id of the publish message (for QoS 0 message_id will always
- * be zero) on success. -1 on failure, -2 in case of full outbox.
+ * be zero) on success. -1 on failure (including an invalid `property`), -2 in
+ * case of full outbox.
  */
 int esp_mqtt_client_publish5(esp_mqtt_client_handle_t client, const char *topic,
                              const char *data, int len, int qos, int retain,
@@ -707,9 +736,18 @@ int esp_mqtt_client_enqueue(esp_mqtt_client_handle_t client, const char *topic,
  *
  * Same behavior as `esp_mqtt_client_enqueue`, but the publish properties
  * (including user properties) passed in `property` are applied directly to this
- * message atomically. Properties set via `esp_mqtt5_client_set_publish_property`
- * still apply as a base for this message, and any field present in `property`
- * overrides it.
+ * message atomically, so no separate `esp_mqtt5_client_set_publish_property`
+ * call is required and it is safe to call from multiple tasks.
+ *
+ * A non-NULL `property` is used *instead of* anything staged via
+ * `esp_mqtt5_client_set_publish_property` — the two are not merged, and the
+ * staged property is left in place for the next plain enqueue. Passing NULL
+ * falls back to the staged property (and consumes it) exactly like
+ * `esp_mqtt_client_enqueue`.
+ *
+ * `property` is validated the same way `esp_mqtt5_client_set_publish_property`
+ * validates it (`topic_alias` against the server maximum); an invalid property
+ * is rejected instead of being put on the wire.
  *
  * @param client    *MQTT* client handle
  * @param topic     topic string
@@ -723,7 +761,8 @@ int esp_mqtt_client_enqueue(esp_mqtt_client_handle_t client, const char *topic,
  * @param property  publish properties for this message, may be NULL to use the
  * properties set via `esp_mqtt5_client_set_publish_property`
  *
- * @return message_id if queued successfully, -1 on failure, -2 in case of full outbox.
+ * @return message_id if queued successfully, -1 on failure (including an
+ * invalid `property`), -2 in case of full outbox.
  */
 int esp_mqtt_client_enqueue5(esp_mqtt_client_handle_t client, const char *topic,
                              const char *data, int len, int qos, int retain,

--- a/include/mqtt_client.h
+++ b/include/mqtt_client.h
@@ -522,6 +522,32 @@ esp_err_t esp_mqtt_client_stop(esp_mqtt_client_handle_t client);
  */
 int esp_mqtt_client_subscribe_single(esp_mqtt_client_handle_t client,
                                      const char *topic, int qos);
+
+#ifdef CONFIG_MQTT_PROTOCOL_5
+/**
+ * @brief Subscribe the client to a defined topic with defined qos, overriding
+ * the MQTT v5 subscribe properties for this single message.
+ *
+ * Same behavior as `esp_mqtt_client_subscribe_single`, but the subscribe
+ * properties (including user properties) passed in `property` are applied
+ * directly to this message atomically. Properties set via
+ * `esp_mqtt5_client_set_subscribe_property` still apply as a base for this
+ * message, and any field present in `property` overrides it.
+ *
+ * @param client    *MQTT* client handle
+ * @param topic topic filter to subscribe
+ * @param qos Max qos level of the subscription
+ * @param property  subscribe properties for this message, may be NULL to use the
+ * properties set via `esp_mqtt5_client_set_subscribe_property`
+ *
+ * @return message_id of the subscribe message on success
+ *         -1 on failure
+ *         -2 in case of full outbox.
+ */
+int esp_mqtt_client_subscribe5(esp_mqtt_client_handle_t client,
+                               const char *topic, int qos,
+                               const esp_mqtt5_subscribe_property_config_t *property);
+#endif
 /**
  * @brief Subscribe the client to a list of defined topics with defined qos
  *
@@ -560,6 +586,30 @@ int esp_mqtt_client_subscribe_multiple(esp_mqtt_client_handle_t client,
 int esp_mqtt_client_unsubscribe(esp_mqtt_client_handle_t client,
                                 const char *topic);
 
+#ifdef CONFIG_MQTT_PROTOCOL_5
+/**
+ * @brief Unsubscribe the client from defined topic, overriding the MQTT v5
+ * unsubscribe properties for this single message.
+ *
+ * Same behavior as `esp_mqtt_client_unsubscribe`, but the unsubscribe
+ * properties (including user properties) passed in `property` are applied
+ * directly to this message atomically. Properties set via
+ * `esp_mqtt5_client_set_unsubscribe_property` still apply as a base for this
+ * message, and any field present in `property` overrides it.
+ *
+ * @param client    *MQTT* client handle
+ * @param topic
+ * @param property  unsubscribe properties for this message, may be NULL to use
+ * the properties set via `esp_mqtt5_client_set_unsubscribe_property`
+ *
+ * @return message_id of the subscribe message on success
+ *         -1 on failure
+ */
+int esp_mqtt_client_unsubscribe5(esp_mqtt_client_handle_t client,
+                                 const char *topic,
+                                 const esp_mqtt5_unsubscribe_property_config_t *property);
+#endif
+
 /**
  * @brief Client to send a publish message to the broker
  *
@@ -592,6 +642,36 @@ int esp_mqtt_client_unsubscribe(esp_mqtt_client_handle_t client,
 int esp_mqtt_client_publish(esp_mqtt_client_handle_t client, const char *topic,
                             const char *data, int len, int qos, int retain);
 
+#ifdef CONFIG_MQTT_PROTOCOL_5
+/**
+ * @brief Client to send a publish message to the broker, overriding the
+ * MQTT v5 publish properties for this single message.
+ *
+ * Same behavior as `esp_mqtt_client_publish`, but the publish properties
+ * (including user properties) passed in `property` are applied directly to this
+ * message atomically (no separate `esp_mqtt5_client_set_publish_property` call
+ * is required, so it is safe to call from multiple tasks). Properties set via
+ * `esp_mqtt5_client_set_publish_property` still apply as a base for this
+ * message, and any field present in `property` overrides it.
+ *
+ * @param client    *MQTT* client handle
+ * @param topic     topic string
+ * @param data      payload string (set to NULL, sending empty payload message)
+ * @param len       data length, if set to 0, length is calculated from payload
+ * string
+ * @param qos       QoS of publish message
+ * @param retain    retain flag
+ * @param property  publish properties for this message, may be NULL to use the
+ * properties set via `esp_mqtt5_client_set_publish_property`
+ *
+ * @return message_id of the publish message (for QoS 0 message_id will always
+ * be zero) on success. -1 on failure, -2 in case of full outbox.
+ */
+int esp_mqtt_client_publish5(esp_mqtt_client_handle_t client, const char *topic,
+                             const char *data, int len, int qos, int retain,
+                             const esp_mqtt5_publish_property_config_t *property);
+#endif
+
 /**
  * @brief Enqueue a message to the outbox, to be sent later. Typically used for
  * messages with qos>0, but could be also used for qos=0 messages if store=true.
@@ -619,6 +699,37 @@ int esp_mqtt_client_publish(esp_mqtt_client_handle_t client, const char *topic,
 int esp_mqtt_client_enqueue(esp_mqtt_client_handle_t client, const char *topic,
                             const char *data, int len, int qos, int retain,
                             bool store);
+
+#ifdef CONFIG_MQTT_PROTOCOL_5
+/**
+ * @brief Enqueue a message to the outbox, to be sent later, overriding the
+ * MQTT v5 publish properties for this single message.
+ *
+ * Same behavior as `esp_mqtt_client_enqueue`, but the publish properties
+ * (including user properties) passed in `property` are applied directly to this
+ * message atomically. Properties set via `esp_mqtt5_client_set_publish_property`
+ * still apply as a base for this message, and any field present in `property`
+ * overrides it.
+ *
+ * @param client    *MQTT* client handle
+ * @param topic     topic string
+ * @param data      payload string (set to NULL, sending empty payload message)
+ * @param len       data length, if set to 0, length is calculated from payload
+ * string
+ * @param qos       QoS of publish message
+ * @param retain    retain flag
+ * @param store     if true, all messages are enqueued; otherwise only QoS 1 and
+ * QoS 2 are enqueued
+ * @param property  publish properties for this message, may be NULL to use the
+ * properties set via `esp_mqtt5_client_set_publish_property`
+ *
+ * @return message_id if queued successfully, -1 on failure, -2 in case of full outbox.
+ */
+int esp_mqtt_client_enqueue5(esp_mqtt_client_handle_t client, const char *topic,
+                             const char *data, int len, int qos, int retain,
+                             bool store,
+                             const esp_mqtt5_publish_property_config_t *property);
+#endif
 
 /**
  * @brief Destroys the client handle

--- a/lib/include/mqtt5_client_priv.h
+++ b/lib/include/mqtt5_client_priv.h
@@ -47,6 +47,23 @@ void esp_mqtt5_client_destory(esp_mqtt5_client_handle_t client);
 esp_err_t esp_mqtt5_client_check_inflight_maximum(esp_mqtt5_client_handle_t client);
 esp_err_t esp_mqtt5_client_publish_check(esp_mqtt5_client_handle_t client, int qos, int retain);
 esp_err_t esp_mqtt5_client_subscribe_check(esp_mqtt5_client_handle_t client, int qos);
+
+/*
+ * Property validators. These are the single source of truth for what makes a property set
+ * legal to put on the wire, and they are shared by the `esp_mqtt5_client_set_*_property()`
+ * setters and by the per-message `esp_mqtt_client_*5()` entry points. A property set that
+ * reaches mqtt5_msg_*() without passing through the matching validator can crash the
+ * encoder (NULL share name) or emit a packet the broker answers with a protocol-error
+ * DISCONNECT.
+ *
+ * A NULL `property` is valid and means "no properties"; the caller must hold the API lock.
+ */
+esp_err_t esp_mqtt5_client_validate_publish_property(esp_mqtt5_client_handle_t client,
+                                                     const esp_mqtt5_publish_property_config_t *property);
+esp_err_t esp_mqtt5_client_validate_subscribe_property(esp_mqtt5_client_handle_t client,
+                                                       const esp_mqtt5_subscribe_property_config_t *property);
+esp_err_t esp_mqtt5_client_validate_unsubscribe_property(esp_mqtt5_client_handle_t client,
+                                                         const esp_mqtt5_unsubscribe_property_config_t *property);
 esp_err_t esp_mqtt5_create_default_config(esp_mqtt5_client_handle_t client);
 esp_err_t esp_mqtt5_get_publish_data(esp_mqtt5_client_handle_t client, uint8_t *msg_buf, size_t msg_read_len,
                                      char **msg_topic, size_t *msg_topic_len, char **msg_data, size_t *msg_data_len);

--- a/mqtt5_client.c
+++ b/mqtt5_client.c
@@ -500,6 +500,106 @@ static esp_err_t esp_mqtt5_user_property_copy(mqtt5_user_property_handle_t user_
     return ESP_OK;
 }
 
+/* Common to every property type: properties only exist on the v5 wire. */
+static esp_err_t esp_mqtt5_client_validate_protocol(esp_mqtt5_client_handle_t client)
+{
+    if (client->mqtt_state.connection.information.protocol_ver != MQTT_PROTOCOL_V_5) {
+        ESP_LOGE(TAG, "MQTT protocol version is not v5");
+        return ESP_FAIL;
+    }
+
+    return ESP_OK;
+}
+
+/* Shared by subscribe and unsubscribe: $share/{share_name}/{topic} needs a usable name,
+   and the encoder dereferences share_name unconditionally once is_share_subscribe is set. */
+static esp_err_t esp_mqtt5_client_validate_share(esp_mqtt5_client_handle_t client, const char *share_name)
+{
+    if (!client->mqtt5_config->server_resp_property_info.shared_subscribe_available) {
+        ESP_LOGE(TAG, "MQTT broker not support shared subscribe");
+        return ESP_FAIL;
+    }
+
+    if (!share_name || !strlen(share_name)) {
+        ESP_LOGE(TAG, "Share name can't be empty for shared subscribe");
+        return ESP_FAIL;
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t esp_mqtt5_client_validate_publish_property(esp_mqtt5_client_handle_t client,
+                                                     const esp_mqtt5_publish_property_config_t *property)
+{
+    if (!property) {
+        return ESP_OK;
+    }
+
+    if (esp_mqtt5_client_validate_protocol(client) != ESP_OK) {
+        return ESP_FAIL;
+    }
+
+    /* Check topic alias less than server maximum topic alias */
+    if (property->topic_alias > client->mqtt5_config->server_resp_property_info.topic_alias_maximum) {
+        ESP_LOGE(TAG, "Topic alias %d is bigger than server support %d", property->topic_alias,
+                 client->mqtt5_config->server_resp_property_info.topic_alias_maximum);
+        return ESP_FAIL;
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t esp_mqtt5_client_validate_subscribe_property(esp_mqtt5_client_handle_t client,
+                                                       const esp_mqtt5_subscribe_property_config_t *property)
+{
+    if (!property) {
+        return ESP_OK;
+    }
+
+    if (esp_mqtt5_client_validate_protocol(client) != ESP_OK) {
+        return ESP_FAIL;
+    }
+
+    if (property->retain_handle > 2) {
+        ESP_LOGE(TAG, "retain_handle only support 0, 1, 2");
+        return ESP_FAIL;
+    }
+
+    if (property->is_share_subscribe) {
+        if (property->no_local_flag) {
+            // MQTT-3.8.3-4 not allow that No Local bit to 1 on a Shared Subscription
+            ESP_LOGE(TAG, "Protocol error that no local flag set on shared subscription");
+            return ESP_FAIL;
+        }
+
+        if (esp_mqtt5_client_validate_share(client, property->share_name) != ESP_OK) {
+            return ESP_FAIL;
+        }
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t esp_mqtt5_client_validate_unsubscribe_property(esp_mqtt5_client_handle_t client,
+                                                         const esp_mqtt5_unsubscribe_property_config_t *property)
+{
+    if (!property) {
+        return ESP_OK;
+    }
+
+    if (esp_mqtt5_client_validate_protocol(client) != ESP_OK) {
+        return ESP_FAIL;
+    }
+
+    if (property->is_share_subscribe) {
+        if (esp_mqtt5_client_validate_share(client, property->share_name) != ESP_OK) {
+            return ESP_FAIL;
+        }
+    }
+
+    return ESP_OK;
+}
+
 esp_err_t esp_mqtt5_client_set_publish_property(esp_mqtt5_client_handle_t client,
                                                 const esp_mqtt5_publish_property_config_t *property)
 {
@@ -510,17 +610,7 @@ esp_err_t esp_mqtt5_client_set_publish_property(esp_mqtt5_client_handle_t client
 
     MQTT_API_LOCK(client);
 
-    /* Check protocol version */
-    if (client->mqtt_state.connection.information.protocol_ver != MQTT_PROTOCOL_V_5) {
-        ESP_LOGE(TAG, "MQTT protocol version is not v5");
-        MQTT_API_UNLOCK(client);
-        return ESP_FAIL;
-    }
-
-    /* Check topic alias less than server maximum topic alias */
-    if (property->topic_alias > client->mqtt5_config->server_resp_property_info.topic_alias_maximum) {
-        ESP_LOGE(TAG, "Topic alias %d is bigger than server support %d", property->topic_alias,
-                 client->mqtt5_config->server_resp_property_info.topic_alias_maximum);
+    if (esp_mqtt5_client_validate_publish_property(client, property) != ESP_OK) {
         MQTT_API_UNLOCK(client);
         return ESP_FAIL;
     }
@@ -538,39 +628,11 @@ esp_err_t esp_mqtt5_client_set_subscribe_property(esp_mqtt5_client_handle_t clie
         return ESP_ERR_INVALID_ARG;
     }
 
-    if (property->retain_handle > 2) {
-        ESP_LOGE(TAG, "retain_handle only support 0, 1, 2");
-        return -1;
-    }
-
     MQTT_API_LOCK(client);
 
-    /* Check protocol version */
-    if (client->mqtt_state.connection.information.protocol_ver != MQTT_PROTOCOL_V_5) {
-        ESP_LOGE(TAG, "MQTT protocol version is not v5");
+    if (esp_mqtt5_client_validate_subscribe_property(client, property) != ESP_OK) {
         MQTT_API_UNLOCK(client);
         return ESP_FAIL;
-    }
-
-    if (property->is_share_subscribe) {
-        if (property->no_local_flag) {
-            // MQTT-3.8.3-4 not allow that No Local bit to 1 on a Shared Subscription
-            ESP_LOGE(TAG, "Protocol error that no local flag set on shared subscription");
-            MQTT_API_UNLOCK(client);
-            return ESP_FAIL;
-        }
-
-        if (!client->mqtt5_config->server_resp_property_info.shared_subscribe_available) {
-            ESP_LOGE(TAG, "MQTT broker not support shared subscribe");
-            MQTT_API_UNLOCK(client);
-            return ESP_FAIL;
-        }
-
-        if (!property->share_name || !strlen(property->share_name)) {
-            ESP_LOGE(TAG, "Share name can't be empty for shared subscribe");
-            MQTT_API_UNLOCK(client);
-            return ESP_FAIL;
-        }
     }
 
     client->mqtt5_config->subscribe_property_info = property;
@@ -588,25 +650,9 @@ esp_err_t esp_mqtt5_client_set_unsubscribe_property(esp_mqtt5_client_handle_t cl
 
     MQTT_API_LOCK(client);
 
-    /* Check protocol version */
-    if (client->mqtt_state.connection.information.protocol_ver != MQTT_PROTOCOL_V_5) {
-        ESP_LOGE(TAG, "MQTT protocol version is not v5");
+    if (esp_mqtt5_client_validate_unsubscribe_property(client, property) != ESP_OK) {
         MQTT_API_UNLOCK(client);
         return ESP_FAIL;
-    }
-
-    if (property->is_share_subscribe) {
-        if (!client->mqtt5_config->server_resp_property_info.shared_subscribe_available) {
-            ESP_LOGE(TAG, "MQTT broker not support shared subscribe");
-            MQTT_API_UNLOCK(client);
-            return ESP_FAIL;
-        }
-
-        if (!property->share_name || !strlen(property->share_name)) {
-            ESP_LOGE(TAG, "Share name can't be empty for shared subscribe");
-            MQTT_API_UNLOCK(client);
-            return ESP_FAIL;
-        }
     }
 
     client->mqtt5_config->unsubscribe_property_info = property;

--- a/mqtt_client.c
+++ b/mqtt_client.c
@@ -2351,121 +2351,6 @@ static esp_err_t esp_mqtt_client_ping(esp_mqtt_client_handle_t client)
     return ESP_OK;
 }
 
-#ifdef MQTT_PROTOCOL_5
-static void mqtt5_merge_publish_property(const esp_mqtt5_publish_property_config_t *base,
-                                         const esp_mqtt5_publish_property_config_t *override,
-                                         esp_mqtt5_publish_property_config_t *out)
-{
-    if (base) {
-        *out = *base;
-    } else {
-        memset(out, 0, sizeof(*out));
-    }
-
-    if (!override) {
-        return;
-    }
-
-    if (override->payload_format_indicator) {
-        out->payload_format_indicator = override->payload_format_indicator;
-    }
-
-    if (override->message_expiry_interval) {
-        out->message_expiry_interval = override->message_expiry_interval;
-    }
-
-    if (override->topic_alias) {
-        out->topic_alias = override->topic_alias;
-    }
-
-    if (override->response_topic) {
-        out->response_topic = override->response_topic;
-    }
-
-    if (override->correlation_data && override->correlation_data_len) {
-        out->correlation_data = override->correlation_data;
-        out->correlation_data_len = override->correlation_data_len;
-    }
-
-    if (override->content_type) {
-        out->content_type = override->content_type;
-    }
-
-    if (override->user_property) {
-        out->user_property = override->user_property;
-    }
-}
-
-static void mqtt5_merge_subscribe_property(const esp_mqtt5_subscribe_property_config_t *base,
-                                           const esp_mqtt5_subscribe_property_config_t *override,
-                                           esp_mqtt5_subscribe_property_config_t *out)
-{
-    if (base) {
-        *out = *base;
-    } else {
-        memset(out, 0, sizeof(*out));
-    }
-
-    if (!override) {
-        return;
-    }
-
-    if (override->subscribe_id) {
-        out->subscribe_id = override->subscribe_id;
-    }
-
-    if (override->no_local_flag) {
-        out->no_local_flag = override->no_local_flag;
-    }
-
-    if (override->retain_as_published_flag) {
-        out->retain_as_published_flag = override->retain_as_published_flag;
-    }
-
-    if (override->retain_handle) {
-        out->retain_handle = override->retain_handle;
-    }
-
-    if (override->is_share_subscribe) {
-        out->is_share_subscribe = override->is_share_subscribe;
-    }
-
-    if (override->share_name) {
-        out->share_name = override->share_name;
-    }
-
-    if (override->user_property) {
-        out->user_property = override->user_property;
-    }
-}
-
-static void mqtt5_merge_unsubscribe_property(const esp_mqtt5_unsubscribe_property_config_t *base,
-                                             const esp_mqtt5_unsubscribe_property_config_t *override,
-                                             esp_mqtt5_unsubscribe_property_config_t *out)
-{
-    if (base) {
-        *out = *base;
-    } else {
-        memset(out, 0, sizeof(*out));
-    }
-
-    if (!override) {
-        return;
-    }
-
-    if (override->is_share_subscribe) {
-        out->is_share_subscribe = override->is_share_subscribe;
-    }
-
-    if (override->share_name) {
-        out->share_name = override->share_name;
-    }
-
-    if (override->user_property) {
-        out->user_property = override->user_property;
-    }
-}
-#endif
 static int mqtt_client_subscribe_multiple_internal(esp_mqtt_client_handle_t client,
                                                    const esp_mqtt_topic_t *topic_list, int size
 #ifdef MQTT_PROTOCOL_5
@@ -2505,6 +2390,15 @@ static int mqtt_client_subscribe_multiple_internal(esp_mqtt_client_handle_t clie
     }
 
     MQTT_API_LOCK(client);
+#ifdef MQTT_PROTOCOL_5
+
+    if (esp_mqtt5_client_validate_subscribe_property(client, subscribe_property) != ESP_OK) {
+        ESP_LOGE(TAG, "Invalid MQTT5 subscribe property");
+        MQTT_API_UNLOCK(client);
+        return -1;
+    }
+
+#endif
     // Reset pending state to avoid inheriting previous PUBLISH QoS or type
     mqtt_reset_pending_message(client);
 
@@ -2524,19 +2418,16 @@ static int mqtt_client_subscribe_multiple_internal(esp_mqtt_client_handle_t clie
             return -1;
         }
 
-        esp_mqtt5_subscribe_property_config_t merged_property;
-        const esp_mqtt5_subscribe_property_config_t *property = client->mqtt5_config->subscribe_property_info;
-
-        if (subscribe_property) {
-            mqtt5_merge_subscribe_property(client->mqtt5_config->subscribe_property_info, subscribe_property, &merged_property);
-            property = &merged_property;
-        }
-
+        /* A per-message property replaces the staged one entirely and leaves it untouched,
+           so a concurrent esp_mqtt5_client_set_subscribe_property() is neither consumed nor
+           partially mixed in. */
+        const esp_mqtt5_subscribe_property_config_t *property = subscribe_property ? subscribe_property :
+                                                                client->mqtt5_config->subscribe_property_info;
         mqtt5_msg_subscribe(&client->mqtt_state.connection,
                             topic_list, size,
                             &client->mqtt_state.pending_msg_id, property);
 
-        if (client->mqtt_state.connection.outbound_message.length) {
+        if (!subscribe_property && client->mqtt_state.connection.outbound_message.length) {
             client->mqtt5_config->subscribe_property_info = NULL;
         }
 
@@ -2629,24 +2520,30 @@ static int esp_mqtt_client_unsubscribe_internal(esp_mqtt_client_handle_t client,
     }
 
     MQTT_API_LOCK(client);
+#ifdef MQTT_PROTOCOL_5
+
+    if (esp_mqtt5_client_validate_unsubscribe_property(client, unsubscribe_property) != ESP_OK) {
+        ESP_LOGE(TAG, "Invalid MQTT5 unsubscribe property");
+        MQTT_API_UNLOCK(client);
+        return -1;
+    }
+
+#endif
     // Reset pending state to avoid inheriting previous PUBLISH QoS or type
     mqtt_reset_pending_message(client);
 
     if (client->mqtt_state.connection.information.protocol_ver == MQTT_PROTOCOL_V_5) {
 #ifdef MQTT_PROTOCOL_5
-        esp_mqtt5_unsubscribe_property_config_t merged_property;
-        const esp_mqtt5_unsubscribe_property_config_t *property = client->mqtt5_config->unsubscribe_property_info;
-
-        if (unsubscribe_property) {
-            mqtt5_merge_unsubscribe_property(client->mqtt5_config->unsubscribe_property_info, unsubscribe_property, &merged_property);
-            property = &merged_property;
-        }
-
+        /* A per-message property replaces the staged one entirely and leaves it untouched,
+           so a concurrent esp_mqtt5_client_set_unsubscribe_property() is neither consumed nor
+           partially mixed in. */
+        const esp_mqtt5_unsubscribe_property_config_t *property = unsubscribe_property ? unsubscribe_property :
+                                                                  client->mqtt5_config->unsubscribe_property_info;
         mqtt5_msg_unsubscribe(&client->mqtt_state.connection,
                               topic,
                               &client->mqtt_state.pending_msg_id, property);
 
-        if (client->mqtt_state.connection.outbound_message.length) {
+        if (!unsubscribe_property && client->mqtt_state.connection.outbound_message.length) {
             client->mqtt5_config->unsubscribe_property_info = NULL;
         }
 
@@ -2698,21 +2595,18 @@ static int make_publish(esp_mqtt_client_handle_t client, const char *topic, cons
 
     if (client->mqtt_state.connection.information.protocol_ver == MQTT_PROTOCOL_V_5) {
 #ifdef MQTT_PROTOCOL_5
-        esp_mqtt5_publish_property_config_t merged_property;
-        const esp_mqtt5_publish_property_config_t *property = client->mqtt5_config->publish_property_info;
-
-        if (publish_property) {
-            mqtt5_merge_publish_property(client->mqtt5_config->publish_property_info, publish_property, &merged_property);
-            property = &merged_property;
-        }
-
+        /* A per-message property replaces the staged one entirely and leaves it untouched,
+           so a concurrent esp_mqtt5_client_set_publish_property() is neither consumed nor
+           partially mixed in. */
+        const esp_mqtt5_publish_property_config_t *property = publish_property ? publish_property :
+                                                              client->mqtt5_config->publish_property_info;
         mqtt5_msg_publish(&client->mqtt_state.connection,
                           topic, data, len,
                           qos, retain,
                           &pending_msg_id, property,
                           client->mqtt5_config->server_resp_property_info.response_info);
 
-        if (client->mqtt_state.connection.outbound_message.length) {
+        if (!publish_property && client->mqtt_state.connection.outbound_message.length) {
             client->mqtt5_config->publish_property_info = NULL;
         }
 
@@ -2777,117 +2671,22 @@ static inline int mqtt_client_enqueue_publish(esp_mqtt_client_handle_t client, c
     return pending_msg_id;
 }
 
+#ifdef MQTT_PROTOCOL_5
+static int esp_mqtt_client_publish_internal(esp_mqtt_client_handle_t client, const char *topic, const char *data,
+                                            int len, int qos, int retain,
+                                            const esp_mqtt5_publish_property_config_t *publish_property);
+#else
+static int esp_mqtt_client_publish_internal(esp_mqtt_client_handle_t client, const char *topic, const char *data,
+                                            int len, int qos, int retain);
+#endif
+
 int esp_mqtt_client_publish(esp_mqtt_client_handle_t client, const char *topic, const char *data, int len, int qos,
                             int retain)
 {
 #ifdef MQTT_PROTOCOL_5
-    return esp_mqtt_client_publish5(client, topic, data, len, qos, retain, NULL);
+    return esp_mqtt_client_publish_internal(client, topic, data, len, qos, retain, NULL);
 #else
-
-    if (!client) {
-        ESP_LOGE(TAG, "Client was not initialized");
-        return -1;
-    }
-
-#if MQTT_SKIP_PUBLISH_IF_DISCONNECTED
-
-    if (client->state != MQTT_STATE_CONNECTED) {
-        ESP_LOGI(TAG, "Publishing skipped: client is not connected");
-        return -1;
-    }
-
-#endif
-    MQTT_API_LOCK(client);
-
-    /* Acceptable publish messages:
-        data == NULL, len == 0: publish null message
-        data valid,   len == 0: publish all data, payload len is determined from string length
-        data valid,   len >  0: publish data with defined length
-     */
-    if (len <= 0 && data != NULL) {
-        len = strlen(data);
-    }
-
-    if (client->config->outbox_limit > 0 && qos > 0) {
-        if (len + outbox_get_size(client->outbox) > client->config->outbox_limit) {
-            MQTT_API_UNLOCK(client);
-            return -2;
-        }
-    }
-
-    int pending_msg_id = mqtt_client_enqueue_publish(client, topic, data, len, qos, retain, false);
-
-    if (pending_msg_id < 0) {
-        MQTT_API_UNLOCK(client);
-        return -1;
-    }
-
-    int ret = 0;
-
-    /* Skip sending if not connected (rely on resending) */
-    if (client->state != MQTT_STATE_CONNECTED) {
-        ESP_LOGD(TAG, "Publish: client is not connected");
-
-        if (qos > 0) {
-            ret = pending_msg_id;
-        } else {
-            ret = -1;
-        }
-
-        goto cannot_publish;
-    }
-
-    /* Provide support for sending fragmented message if it doesn't fit buffer */
-    int remaining_len = len;
-    const char *current_data = data;
-    bool sending = true;
-
-    while (sending)  {
-        if (esp_mqtt_write(client) != ESP_OK) {
-            esp_mqtt_abort_connection(client);
-            ret = -1;
-            goto cannot_publish;
-        }
-
-        int data_sent = client->mqtt_state.connection.outbound_message.length -
-                        client->mqtt_state.connection.outbound_message.fragmented_msg_data_offset;
-        client->mqtt_state.connection.outbound_message.fragmented_msg_data_offset = 0;
-        client->mqtt_state.connection.outbound_message.fragmented_msg_total_length = 0;
-        remaining_len -= data_sent;
-        current_data +=  data_sent;
-
-        if (remaining_len > 0) {
-            mqtt_connection_t *connection = &client->mqtt_state.connection;
-            ESP_LOGD(TAG, "Sending fragmented message, remains to send %d bytes of %d", remaining_len, len);
-            int write_len = remaining_len > connection->buffer_length ? connection->buffer_length : remaining_len;
-            memcpy(connection->buffer, current_data, write_len);
-            connection->outbound_message.data = connection->buffer;
-            connection->outbound_message.length = write_len;
-            sending = true;
-        } else {
-            // Message was sent correctly
-            sending = false;
-        }
-    }
-
-    if (qos > 0) {
-        //Tick is set after transmit to avoid retransmitting too early due slow network speed / big messages
-        outbox_set_tick(client->outbox, pending_msg_id, platform_tick_get_ms());
-        outbox_set_pending(client->outbox, pending_msg_id, TRANSMITTED);
-    }
-
-    MQTT_API_UNLOCK(client);
-    return pending_msg_id;
-cannot_publish:
-    // clear out possible fragmented publish if failed or skipped
-    client->mqtt_state.connection.outbound_message.fragmented_msg_total_length = 0;
-
-    if (qos == 0) {
-        ESP_LOGW(TAG, "Publish: Losing qos0 data when client not connected");
-    }
-
-    MQTT_API_UNLOCK(client);
-    return ret;
+    return esp_mqtt_client_publish_internal(client, topic, data, len, qos, retain);
 #endif
 }
 
@@ -2895,6 +2694,17 @@ cannot_publish:
 int esp_mqtt_client_publish5(esp_mqtt_client_handle_t client, const char *topic, const char *data, int len, int qos,
                              int retain, const esp_mqtt5_publish_property_config_t *publish_property)
 {
+    return esp_mqtt_client_publish_internal(client, topic, data, len, qos, retain, publish_property);
+}
+
+static int esp_mqtt_client_publish_internal(esp_mqtt_client_handle_t client, const char *topic, const char *data,
+                                            int len, int qos, int retain,
+                                            const esp_mqtt5_publish_property_config_t *publish_property)
+#else
+static int esp_mqtt_client_publish_internal(esp_mqtt_client_handle_t client, const char *topic, const char *data,
+                                            int len, int qos, int retain)
+#endif
+{
     if (!client) {
         ESP_LOGE(TAG, "Client was not initialized");
         return -1;
@@ -2910,6 +2720,12 @@ int esp_mqtt_client_publish5(esp_mqtt_client_handle_t client, const char *topic,
 #endif
     MQTT_API_LOCK(client);
 #ifdef MQTT_PROTOCOL_5
+
+    if (esp_mqtt5_client_validate_publish_property(client, publish_property) != ESP_OK) {
+        ESP_LOGE(TAG, "Invalid MQTT5 publish property");
+        MQTT_API_UNLOCK(client);
+        return -1;
+    }
 
     if (client->mqtt_state.connection.information.protocol_ver == MQTT_PROTOCOL_V_5) {
         if (esp_mqtt5_client_publish_check(client, qos, retain) != ESP_OK) {
@@ -2937,7 +2753,11 @@ int esp_mqtt_client_publish5(esp_mqtt_client_handle_t client, const char *topic,
         }
     }
 
-    int pending_msg_id = mqtt_client_enqueue_publish(client, topic, data, len, qos, retain, false, publish_property);
+    int pending_msg_id = mqtt_client_enqueue_publish(client, topic, data, len, qos, retain, false
+#ifdef MQTT_PROTOCOL_5
+                                                     , publish_property
+#endif
+                                                    );
 
     if (pending_msg_id < 0) {
         MQTT_API_UNLOCK(client);
@@ -3029,7 +2849,6 @@ cannot_publish:
     MQTT_API_UNLOCK(client);
     return ret;
 }
-#endif
 
 #ifdef MQTT_PROTOCOL_5
 static int esp_mqtt_client_enqueue_internal(esp_mqtt_client_handle_t client, const char *topic, const char *data, int len,
@@ -3083,6 +2902,12 @@ int esp_mqtt_client_enqueue(esp_mqtt_client_handle_t client, const char *topic, 
 
     MQTT_API_LOCK(client);
 #ifdef MQTT_PROTOCOL_5
+
+    if (esp_mqtt5_client_validate_publish_property(client, publish_property) != ESP_OK) {
+        ESP_LOGE(TAG, "Invalid MQTT5 publish property");
+        MQTT_API_UNLOCK(client);
+        return -1;
+    }
 
     if (client->mqtt_state.connection.information.protocol_ver == MQTT_PROTOCOL_V_5) {
         if (esp_mqtt5_client_publish_check(client, qos, retain) != ESP_OK) {

--- a/mqtt_client.c
+++ b/mqtt_client.c
@@ -2686,12 +2686,14 @@ static int esp_mqtt_client_unsubscribe_internal(esp_mqtt_client_handle_t client,
 }
 
 
-static int make_publish(esp_mqtt_client_handle_t client, const char *topic, const char *data,
-                        int len, int qos, int retain
 #ifdef MQTT_PROTOCOL_5
-                        , const esp_mqtt5_publish_property_config_t *publish_property
+static int make_publish(esp_mqtt_client_handle_t client, const char *topic, const char *data,
+                        int len, int qos, int retain,
+                        const esp_mqtt5_publish_property_config_t *publish_property)
+#else
+static int make_publish(esp_mqtt_client_handle_t client, const char *topic, const char *data,
+                        int len, int qos, int retain)
 #endif
-                       )
 {
     uint16_t pending_msg_id = 0;
 
@@ -2730,12 +2732,14 @@ static int make_publish(esp_mqtt_client_handle_t client, const char *topic, cons
 
     return pending_msg_id;
 }
-static inline int mqtt_client_enqueue_publish(esp_mqtt_client_handle_t client, const char *topic, const char *data,
-                                              int len, int qos, int retain, bool store
 #ifdef MQTT_PROTOCOL_5
-                                              , const esp_mqtt5_publish_property_config_t *publish_property
+static inline int mqtt_client_enqueue_publish(esp_mqtt_client_handle_t client, const char *topic, const char *data,
+                                              int len, int qos, int retain, bool store,
+                                              const esp_mqtt5_publish_property_config_t *publish_property)
+#else
+static inline int mqtt_client_enqueue_publish(esp_mqtt_client_handle_t client, const char *topic, const char *data,
+                                              int len, int qos, int retain, bool store)
 #endif
-                                             )
 {
     int pending_msg_id = make_publish(client, topic, data, len, qos, retain
 #ifdef MQTT_PROTOCOL_5
@@ -2811,11 +2815,7 @@ int esp_mqtt_client_publish(esp_mqtt_client_handle_t client, const char *topic, 
         }
     }
 
-    int pending_msg_id = mqtt_client_enqueue_publish(client, topic, data, len, qos, retain, false
-#ifdef MQTT_PROTOCOL_5
-                                                    , NULL
-#endif
-                                                   );
+    int pending_msg_id = mqtt_client_enqueue_publish(client, topic, data, len, qos, retain, false);
 
     if (pending_msg_id < 0) {
         MQTT_API_UNLOCK(client);
@@ -3097,7 +3097,7 @@ int esp_mqtt_client_enqueue(esp_mqtt_client_handle_t client, const char *topic, 
 #ifdef MQTT_PROTOCOL_5
                                           , publish_property
 #endif
-                                          );
+                                         );
     MQTT_API_UNLOCK(client);
 
     if (ret == 0 && store == false) {

--- a/mqtt_client.c
+++ b/mqtt_client.c
@@ -2481,6 +2481,13 @@ static int mqtt_client_subscribe_multiple_internal(esp_mqtt_client_handle_t clie
 #ifdef MQTT_PROTOCOL_5
                                                    , const esp_mqtt5_subscribe_property_config_t *subscribe_property
 #endif
+                                                  );
+
+static int mqtt_client_subscribe_multiple_internal(esp_mqtt_client_handle_t client,
+                                                   const esp_mqtt_topic_t *topic_list, int size
+#ifdef MQTT_PROTOCOL_5
+                                                   , const esp_mqtt5_subscribe_property_config_t *subscribe_property
+#endif
                                                   )
 {
     if (!client) {
@@ -2580,6 +2587,13 @@ int esp_mqtt_client_subscribe5(esp_mqtt_client_handle_t client, const char *topi
     esp_mqtt_topic_t user_topic = {.filter = topic, .qos = qos};
     return mqtt_client_subscribe_multiple_internal(client, &user_topic, 1, subscribe_property);
 }
+#endif
+
+#ifdef MQTT_PROTOCOL_5
+static int esp_mqtt_client_unsubscribe_internal(esp_mqtt_client_handle_t client, const char *topic,
+                                                const esp_mqtt5_unsubscribe_property_config_t *unsubscribe_property);
+#else
+static int esp_mqtt_client_unsubscribe_internal(esp_mqtt_client_handle_t client, const char *topic);
 #endif
 
 int esp_mqtt_client_unsubscribe(esp_mqtt_client_handle_t client, const char *topic)
@@ -3015,6 +3029,15 @@ cannot_publish:
     MQTT_API_UNLOCK(client);
     return ret;
 }
+#endif
+
+#ifdef MQTT_PROTOCOL_5
+static int esp_mqtt_client_enqueue_internal(esp_mqtt_client_handle_t client, const char *topic, const char *data, int len,
+                                            int qos, int retain, bool store,
+                                            const esp_mqtt5_publish_property_config_t *publish_property);
+#else
+static int esp_mqtt_client_enqueue_internal(esp_mqtt_client_handle_t client, const char *topic, const char *data, int len,
+                                            int qos, int retain, bool store);
 #endif
 
 #ifdef MQTT_PROTOCOL_5

--- a/mqtt_client.c
+++ b/mqtt_client.c
@@ -2351,8 +2351,137 @@ static esp_err_t esp_mqtt_client_ping(esp_mqtt_client_handle_t client)
     return ESP_OK;
 }
 
+#ifdef MQTT_PROTOCOL_5
+static void mqtt5_merge_publish_property(const esp_mqtt5_publish_property_config_t *base,
+                                         const esp_mqtt5_publish_property_config_t *override,
+                                         esp_mqtt5_publish_property_config_t *out)
+{
+    if (base) {
+        *out = *base;
+    } else {
+        memset(out, 0, sizeof(*out));
+    }
+
+    if (!override) {
+        return;
+    }
+
+    if (override->payload_format_indicator) {
+        out->payload_format_indicator = override->payload_format_indicator;
+    }
+
+    if (override->message_expiry_interval) {
+        out->message_expiry_interval = override->message_expiry_interval;
+    }
+
+    if (override->topic_alias) {
+        out->topic_alias = override->topic_alias;
+    }
+
+    if (override->response_topic) {
+        out->response_topic = override->response_topic;
+    }
+
+    if (override->correlation_data && override->correlation_data_len) {
+        out->correlation_data = override->correlation_data;
+        out->correlation_data_len = override->correlation_data_len;
+    }
+
+    if (override->content_type) {
+        out->content_type = override->content_type;
+    }
+
+    if (override->user_property) {
+        out->user_property = override->user_property;
+    }
+}
+
+static void mqtt5_merge_subscribe_property(const esp_mqtt5_subscribe_property_config_t *base,
+                                           const esp_mqtt5_subscribe_property_config_t *override,
+                                           esp_mqtt5_subscribe_property_config_t *out)
+{
+    if (base) {
+        *out = *base;
+    } else {
+        memset(out, 0, sizeof(*out));
+    }
+
+    if (!override) {
+        return;
+    }
+
+    if (override->subscribe_id) {
+        out->subscribe_id = override->subscribe_id;
+    }
+
+    if (override->no_local_flag) {
+        out->no_local_flag = override->no_local_flag;
+    }
+
+    if (override->retain_as_published_flag) {
+        out->retain_as_published_flag = override->retain_as_published_flag;
+    }
+
+    if (override->retain_handle) {
+        out->retain_handle = override->retain_handle;
+    }
+
+    if (override->is_share_subscribe) {
+        out->is_share_subscribe = override->is_share_subscribe;
+    }
+
+    if (override->share_name) {
+        out->share_name = override->share_name;
+    }
+
+    if (override->user_property) {
+        out->user_property = override->user_property;
+    }
+}
+
+static void mqtt5_merge_unsubscribe_property(const esp_mqtt5_unsubscribe_property_config_t *base,
+                                             const esp_mqtt5_unsubscribe_property_config_t *override,
+                                             esp_mqtt5_unsubscribe_property_config_t *out)
+{
+    if (base) {
+        *out = *base;
+    } else {
+        memset(out, 0, sizeof(*out));
+    }
+
+    if (!override) {
+        return;
+    }
+
+    if (override->is_share_subscribe) {
+        out->is_share_subscribe = override->is_share_subscribe;
+    }
+
+    if (override->share_name) {
+        out->share_name = override->share_name;
+    }
+
+    if (override->user_property) {
+        out->user_property = override->user_property;
+    }
+}
+#endif
 int esp_mqtt_client_subscribe_multiple(esp_mqtt_client_handle_t client,
                                        const esp_mqtt_topic_t *topic_list, int size)
+{
+#ifdef MQTT_PROTOCOL_5
+    return mqtt_client_subscribe_multiple_internal(client, topic_list, size, NULL);
+#else
+    return mqtt_client_subscribe_multiple_internal(client, topic_list, size);
+#endif
+}
+
+static int mqtt_client_subscribe_multiple_internal(esp_mqtt_client_handle_t client,
+                                                   const esp_mqtt_topic_t *topic_list, int size
+#ifdef MQTT_PROTOCOL_5
+                                                   , const esp_mqtt5_subscribe_property_config_t *subscribe_property
+#endif
+                                                  )
 {
     if (!client) {
         ESP_LOGE(TAG, "Client was not initialized");
@@ -2388,9 +2517,17 @@ int esp_mqtt_client_subscribe_multiple(esp_mqtt_client_handle_t client,
             return -1;
         }
 
+        esp_mqtt5_subscribe_property_config_t merged_property;
+        const esp_mqtt5_subscribe_property_config_t *property = client->mqtt5_config->subscribe_property_info;
+
+        if (subscribe_property) {
+            mqtt5_merge_subscribe_property(client->mqtt5_config->subscribe_property_info, subscribe_property, &merged_property);
+            property = &merged_property;
+        }
+
         mqtt5_msg_subscribe(&client->mqtt_state.connection,
                             topic_list, size,
-                            &client->mqtt_state.pending_msg_id, client->mqtt5_config->subscribe_property_info);
+                            &client->mqtt_state.pending_msg_id, property);
 
         if (client->mqtt_state.connection.outbound_message.length) {
             client->mqtt5_config->subscribe_property_info = NULL;
@@ -2436,7 +2573,36 @@ int esp_mqtt_client_subscribe_single(esp_mqtt_client_handle_t client, const char
     return esp_mqtt_client_subscribe_multiple(client, &user_topic, 1);
 }
 
+#ifdef MQTT_PROTOCOL_5
+int esp_mqtt_client_subscribe5(esp_mqtt_client_handle_t client, const char *topic, int qos,
+                               const esp_mqtt5_subscribe_property_config_t *subscribe_property)
+{
+    esp_mqtt_topic_t user_topic = {.filter = topic, .qos = qos};
+    return mqtt_client_subscribe_multiple_internal(client, &user_topic, 1, subscribe_property);
+}
+#endif
+
 int esp_mqtt_client_unsubscribe(esp_mqtt_client_handle_t client, const char *topic)
+{
+#ifdef MQTT_PROTOCOL_5
+    return esp_mqtt_client_unsubscribe5(client, topic, NULL);
+#else
+    return esp_mqtt_client_unsubscribe_internal(client, topic);
+#endif
+}
+
+#ifdef MQTT_PROTOCOL_5
+int esp_mqtt_client_unsubscribe5(esp_mqtt_client_handle_t client, const char *topic,
+                                 const esp_mqtt5_unsubscribe_property_config_t *unsubscribe_property)
+{
+    return esp_mqtt_client_unsubscribe_internal(client, topic, unsubscribe_property);
+}
+
+static int esp_mqtt_client_unsubscribe_internal(esp_mqtt_client_handle_t client, const char *topic,
+                                                const esp_mqtt5_unsubscribe_property_config_t *unsubscribe_property)
+#else
+static int esp_mqtt_client_unsubscribe_internal(esp_mqtt_client_handle_t client, const char *topic)
+#endif
 {
     if (!client) {
         ESP_LOGE(TAG, "Client was not initialized");
@@ -2454,9 +2620,17 @@ int esp_mqtt_client_unsubscribe(esp_mqtt_client_handle_t client, const char *top
 
     if (client->mqtt_state.connection.information.protocol_ver == MQTT_PROTOCOL_V_5) {
 #ifdef MQTT_PROTOCOL_5
+        esp_mqtt5_unsubscribe_property_config_t merged_property;
+        const esp_mqtt5_unsubscribe_property_config_t *property = client->mqtt5_config->unsubscribe_property_info;
+
+        if (unsubscribe_property) {
+            mqtt5_merge_unsubscribe_property(client->mqtt5_config->unsubscribe_property_info, unsubscribe_property, &merged_property);
+            property = &merged_property;
+        }
+
         mqtt5_msg_unsubscribe(&client->mqtt_state.connection,
                               topic,
-                              &client->mqtt_state.pending_msg_id, client->mqtt5_config->unsubscribe_property_info);
+                              &client->mqtt_state.pending_msg_id, property);
 
         if (client->mqtt_state.connection.outbound_message.length) {
             client->mqtt5_config->unsubscribe_property_info = NULL;
@@ -2497,17 +2671,30 @@ int esp_mqtt_client_unsubscribe(esp_mqtt_client_handle_t client, const char *top
     return pending_msg_id;
 }
 
+
 static int make_publish(esp_mqtt_client_handle_t client, const char *topic, const char *data,
-                        int len, int qos, int retain)
+                        int len, int qos, int retain
+#ifdef MQTT_PROTOCOL_5
+                        , const esp_mqtt5_publish_property_config_t *publish_property
+#endif
+                       )
 {
     uint16_t pending_msg_id = 0;
 
     if (client->mqtt_state.connection.information.protocol_ver == MQTT_PROTOCOL_V_5) {
 #ifdef MQTT_PROTOCOL_5
+        esp_mqtt5_publish_property_config_t merged_property;
+        const esp_mqtt5_publish_property_config_t *property = client->mqtt5_config->publish_property_info;
+
+        if (publish_property) {
+            mqtt5_merge_publish_property(client->mqtt5_config->publish_property_info, publish_property, &merged_property);
+            property = &merged_property;
+        }
+
         mqtt5_msg_publish(&client->mqtt_state.connection,
                           topic, data, len,
                           qos, retain,
-                          &pending_msg_id, client->mqtt5_config->publish_property_info,
+                          &pending_msg_id, property,
                           client->mqtt5_config->server_resp_property_info.response_info);
 
         if (client->mqtt_state.connection.outbound_message.length) {
@@ -2530,9 +2717,17 @@ static int make_publish(esp_mqtt_client_handle_t client, const char *topic, cons
     return pending_msg_id;
 }
 static inline int mqtt_client_enqueue_publish(esp_mqtt_client_handle_t client, const char *topic, const char *data,
-                                              int len, int qos, int retain, bool store)
+                                              int len, int qos, int retain, bool store
+#ifdef MQTT_PROTOCOL_5
+                                              , const esp_mqtt5_publish_property_config_t *publish_property
+#endif
+                                             )
 {
-    int pending_msg_id = make_publish(client, topic, data, len, qos, retain);
+    int pending_msg_id = make_publish(client, topic, data, len, qos, retain
+#ifdef MQTT_PROTOCOL_5
+                                      , publish_property
+#endif
+                                     );
 
     if (pending_msg_id < 0) {
         return -1;
@@ -2567,6 +2762,124 @@ static inline int mqtt_client_enqueue_publish(esp_mqtt_client_handle_t client, c
 
 int esp_mqtt_client_publish(esp_mqtt_client_handle_t client, const char *topic, const char *data, int len, int qos,
                             int retain)
+{
+#ifdef MQTT_PROTOCOL_5
+    return esp_mqtt_client_publish5(client, topic, data, len, qos, retain, NULL);
+#else
+    if (!client) {
+        ESP_LOGE(TAG, "Client was not initialized");
+        return -1;
+    }
+
+#if MQTT_SKIP_PUBLISH_IF_DISCONNECTED
+
+    if (client->state != MQTT_STATE_CONNECTED) {
+        ESP_LOGI(TAG, "Publishing skipped: client is not connected");
+        return -1;
+    }
+
+#endif
+    MQTT_API_LOCK(client);
+
+    /* Acceptable publish messages:
+        data == NULL, len == 0: publish null message
+        data valid,   len == 0: publish all data, payload len is determined from string length
+        data valid,   len >  0: publish data with defined length
+     */
+    if (len <= 0 && data != NULL) {
+        len = strlen(data);
+    }
+
+    if (client->config->outbox_limit > 0 && qos > 0) {
+        if (len + outbox_get_size(client->outbox) > client->config->outbox_limit) {
+            MQTT_API_UNLOCK(client);
+            return -2;
+        }
+    }
+
+    int pending_msg_id = mqtt_client_enqueue_publish(client, topic, data, len, qos, retain, false
+#ifdef MQTT_PROTOCOL_5
+                                                    , NULL
+#endif
+                                                   );
+
+    if (pending_msg_id < 0) {
+        MQTT_API_UNLOCK(client);
+        return -1;
+    }
+
+    int ret = 0;
+
+    /* Skip sending if not connected (rely on resending) */
+    if (client->state != MQTT_STATE_CONNECTED) {
+        ESP_LOGD(TAG, "Publish: client is not connected");
+
+        if (qos > 0) {
+            ret = pending_msg_id;
+        } else {
+            ret = -1;
+        }
+
+        goto cannot_publish;
+    }
+
+    /* Provide support for sending fragmented message if it doesn't fit buffer */
+    int remaining_len = len;
+    const char *current_data = data;
+    bool sending = true;
+
+    while (sending)  {
+        if (esp_mqtt_write(client) != ESP_OK) {
+            esp_mqtt_abort_connection(client);
+            ret = -1;
+            goto cannot_publish;
+        }
+
+        int data_sent = client->mqtt_state.connection.outbound_message.length -
+                        client->mqtt_state.connection.outbound_message.fragmented_msg_data_offset;
+        client->mqtt_state.connection.outbound_message.fragmented_msg_data_offset = 0;
+        client->mqtt_state.connection.outbound_message.fragmented_msg_total_length = 0;
+        remaining_len -= data_sent;
+        current_data +=  data_sent;
+
+        if (remaining_len > 0) {
+            mqtt_connection_t *connection = &client->mqtt_state.connection;
+            ESP_LOGD(TAG, "Sending fragmented message, remains to send %d bytes of %d", remaining_len, len);
+            int write_len = remaining_len > connection->buffer_length ? connection->buffer_length : remaining_len;
+            memcpy(connection->buffer, current_data, write_len);
+            connection->outbound_message.data = connection->buffer;
+            connection->outbound_message.length = write_len;
+            sending = true;
+        } else {
+            // Message was sent correctly
+            sending = false;
+        }
+    }
+
+    if (qos > 0) {
+        //Tick is set after transmit to avoid retransmitting too early due slow network speed / big messages
+        outbox_set_tick(client->outbox, pending_msg_id, platform_tick_get_ms());
+        outbox_set_pending(client->outbox, pending_msg_id, TRANSMITTED);
+    }
+
+    MQTT_API_UNLOCK(client);
+    return pending_msg_id;
+cannot_publish:
+    // clear out possible fragmented publish if failed or skipped
+    client->mqtt_state.connection.outbound_message.fragmented_msg_total_length = 0;
+
+    if (qos == 0) {
+        ESP_LOGW(TAG, "Publish: Losing qos0 data when client not connected");
+    }
+
+    MQTT_API_UNLOCK(client);
+    return ret;
+#endif
+}
+
+#ifdef MQTT_PROTOCOL_5
+int esp_mqtt_client_publish5(esp_mqtt_client_handle_t client, const char *topic, const char *data, int len, int qos,
+                             int retain, const esp_mqtt5_publish_property_config_t *publish_property)
 {
     if (!client) {
         ESP_LOGE(TAG, "Client was not initialized");
@@ -2610,7 +2923,7 @@ int esp_mqtt_client_publish(esp_mqtt_client_handle_t client, const char *topic, 
         }
     }
 
-    int pending_msg_id = mqtt_client_enqueue_publish(client, topic, data, len, qos, retain, false);
+    int pending_msg_id = mqtt_client_enqueue_publish(client, topic, data, len, qos, retain, false, publish_property);
 
     if (pending_msg_id < 0) {
         MQTT_API_UNLOCK(client);
@@ -2702,9 +3015,28 @@ cannot_publish:
     MQTT_API_UNLOCK(client);
     return ret;
 }
+#endif
+
+#ifdef MQTT_PROTOCOL_5
+int esp_mqtt_client_enqueue5(esp_mqtt_client_handle_t client, const char *topic, const char *data, int len, int qos,
+                             int retain, bool store, const esp_mqtt5_publish_property_config_t *publish_property)
+{
+    return esp_mqtt_client_enqueue_internal(client, topic, data, len, qos, retain, store, publish_property);
+}
 
 int esp_mqtt_client_enqueue(esp_mqtt_client_handle_t client, const char *topic, const char *data, int len, int qos,
                             int retain, bool store)
+{
+    return esp_mqtt_client_enqueue_internal(client, topic, data, len, qos, retain, store, NULL);
+}
+
+static int esp_mqtt_client_enqueue_internal(esp_mqtt_client_handle_t client, const char *topic, const char *data, int len,
+                                            int qos, int retain, bool store,
+                                            const esp_mqtt5_publish_property_config_t *publish_property)
+#else
+int esp_mqtt_client_enqueue(esp_mqtt_client_handle_t client, const char *topic, const char *data, int len, int qos,
+                            int retain, bool store)
+#endif
 {
     if (!client) {
         ESP_LOGE(TAG, "Client was not initialized");
@@ -2738,7 +3070,11 @@ int esp_mqtt_client_enqueue(esp_mqtt_client_handle_t client, const char *topic, 
     }
 
 #endif
-    int ret = mqtt_client_enqueue_publish(client, topic, data, len, qos, retain, store);
+    int ret = mqtt_client_enqueue_publish(client, topic, data, len, qos, retain, store
+#ifdef MQTT_PROTOCOL_5
+                                          , publish_property
+#endif
+                                          );
     MQTT_API_UNLOCK(client);
 
     if (ret == 0 && store == false) {

--- a/mqtt_client.c
+++ b/mqtt_client.c
@@ -2466,6 +2466,13 @@ static void mqtt5_merge_unsubscribe_property(const esp_mqtt5_unsubscribe_propert
     }
 }
 #endif
+static int mqtt_client_subscribe_multiple_internal(esp_mqtt_client_handle_t client,
+                                                   const esp_mqtt_topic_t *topic_list, int size
+#ifdef MQTT_PROTOCOL_5
+                                                   , const esp_mqtt5_subscribe_property_config_t *subscribe_property
+#endif
+                                                  );
+
 int esp_mqtt_client_subscribe_multiple(esp_mqtt_client_handle_t client,
                                        const esp_mqtt_topic_t *topic_list, int size)
 {
@@ -2475,13 +2482,6 @@ int esp_mqtt_client_subscribe_multiple(esp_mqtt_client_handle_t client,
     return mqtt_client_subscribe_multiple_internal(client, topic_list, size);
 #endif
 }
-
-static int mqtt_client_subscribe_multiple_internal(esp_mqtt_client_handle_t client,
-                                                   const esp_mqtt_topic_t *topic_list, int size
-#ifdef MQTT_PROTOCOL_5
-                                                   , const esp_mqtt5_subscribe_property_config_t *subscribe_property
-#endif
-                                                  );
 
 static int mqtt_client_subscribe_multiple_internal(esp_mqtt_client_handle_t client,
                                                    const esp_mqtt_topic_t *topic_list, int size

--- a/mqtt_client.c
+++ b/mqtt_client.c
@@ -2685,7 +2685,6 @@ static int esp_mqtt_client_unsubscribe_internal(esp_mqtt_client_handle_t client,
     return pending_msg_id;
 }
 
-
 #ifdef MQTT_PROTOCOL_5
 static int make_publish(esp_mqtt_client_handle_t client, const char *topic, const char *data,
                         int len, int qos, int retain,
@@ -2784,6 +2783,7 @@ int esp_mqtt_client_publish(esp_mqtt_client_handle_t client, const char *topic, 
 #ifdef MQTT_PROTOCOL_5
     return esp_mqtt_client_publish5(client, topic, data, len, qos, retain, NULL);
 #else
+
     if (!client) {
         ESP_LOGE(TAG, "Client was not initialized");
         return -1;

--- a/test/host/main/mqtt5_client_test_adapter.c
+++ b/test/host/main/mqtt5_client_test_adapter.c
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <stdbool.h>
 #include <stdint.h>
 
 #include "mqtt_client_priv.h"
@@ -24,4 +25,64 @@ int test_mqtt5_increment_packet_counter_with_dup(void)
     client.mqtt_state.connection.outbound_message.data = publish_header;
     esp_mqtt5_increment_packet_counter(&client);
     return client.send_publish_packet_count;
+}
+
+/* --- property validation -------------------------------------------------
+ *
+ * The per-message esp_mqtt_client_*5() APIs do not go through
+ * esp_mqtt5_client_set_*_property(), so the validators below are the only thing
+ * standing between a caller-supplied property and mqtt5_msg_*(). Two of these
+ * cases used to reach the encoder: a shared subscription with no share name
+ * dereferences NULL in mqtt5_msg_subscribe()/mqtt5_msg_unsubscribe(), and a
+ * topic alias above the server maximum is a protocol error the broker answers
+ * with DISCONNECT.
+ */
+
+/* Broker that supports everything, so a rejection is attributable to the
+   property under test rather than to a server limit. */
+static void test_mqtt5_permissive_client(struct esp_mqtt_client *client, mqtt5_config_storage_t *config,
+                                         esp_mqtt_protocol_ver_t protocol_ver)
+{
+    client->mqtt5_config = config;
+    client->mqtt_state.connection.information.protocol_ver = protocol_ver;
+    config->server_resp_property_info.shared_subscribe_available = true;
+    config->server_resp_property_info.topic_alias_maximum = 10;
+}
+
+esp_err_t test_mqtt5_validate_subscribe_property(const esp_mqtt5_subscribe_property_config_t *property,
+                                                 bool shared_available, esp_mqtt_protocol_ver_t protocol_ver)
+{
+    struct esp_mqtt_client client = {0};
+    mqtt5_config_storage_t mqtt5_config = {0};
+    test_mqtt5_permissive_client(&client, &mqtt5_config, protocol_ver);
+    mqtt5_config.server_resp_property_info.shared_subscribe_available = shared_available;
+    return esp_mqtt5_client_validate_subscribe_property(&client, property);
+}
+
+esp_err_t test_mqtt5_validate_unsubscribe_property(const esp_mqtt5_unsubscribe_property_config_t *property,
+                                                   bool shared_available, esp_mqtt_protocol_ver_t protocol_ver)
+{
+    struct esp_mqtt_client client = {0};
+    mqtt5_config_storage_t mqtt5_config = {0};
+    test_mqtt5_permissive_client(&client, &mqtt5_config, protocol_ver);
+    mqtt5_config.server_resp_property_info.shared_subscribe_available = shared_available;
+    return esp_mqtt5_client_validate_unsubscribe_property(&client, property);
+}
+
+esp_err_t test_mqtt5_validate_publish_property(const esp_mqtt5_publish_property_config_t *property,
+                                               uint16_t topic_alias_maximum, esp_mqtt_protocol_ver_t protocol_ver)
+{
+    struct esp_mqtt_client client = {0};
+    mqtt5_config_storage_t mqtt5_config = {0};
+    test_mqtt5_permissive_client(&client, &mqtt5_config, protocol_ver);
+    mqtt5_config.server_resp_property_info.topic_alias_maximum = topic_alias_maximum;
+    return esp_mqtt5_client_validate_publish_property(&client, property);
+}
+
+/* esp_mqtt5_client_set_publish_property() stages a one-shot property that the
+   next publish consumes. Reading it back is how the test tells "replaced" from
+   "consumed"; the field lives in the private mqtt5 config. */
+const void *test_mqtt5_staged_publish_property(esp_mqtt_client_handle_t client)
+{
+    return client->mqtt5_config->publish_property_info;
 }

--- a/test/host/main/test_mqtt5_client.cpp
+++ b/test/host/main/test_mqtt5_client.cpp
@@ -5,12 +5,64 @@
  */
 #include <catch2/catch_test_macros.hpp>
 #include <cstdint>
+#include <memory>
+#include <type_traits>
 
 #include "esp_err.h"
+#include "esp_transport.h"
+/* mqtt_client.h must come first: mqtt5_client.h sets its own include guard
+   before including mqtt_client.h, so pulling it in first leaves mqtt_client.h
+   without the MQTT5 types its own prototypes reference. */
+#include "mqtt_client.h"
+#include "mqtt5_client.h"
 
 extern "C" {
     esp_err_t test_mqtt5_check_inflight_maximum(uint16_t send_count, uint16_t receive_maximum);
     int test_mqtt5_increment_packet_counter_with_dup(void);
+    esp_err_t test_mqtt5_validate_subscribe_property(const esp_mqtt5_subscribe_property_config_t *property,
+                                                     bool shared_available, esp_mqtt_protocol_ver_t protocol_ver);
+    esp_err_t test_mqtt5_validate_unsubscribe_property(const esp_mqtt5_unsubscribe_property_config_t *property,
+                                                       bool shared_available, esp_mqtt_protocol_ver_t protocol_ver);
+    esp_err_t test_mqtt5_validate_publish_property(const esp_mqtt5_publish_property_config_t *property,
+                                                   uint16_t topic_alias_maximum, esp_mqtt_protocol_ver_t protocol_ver);
+    const void *test_mqtt5_staged_publish_property(esp_mqtt_client_handle_t client);
+
+#include "Mockesp_event.h"
+#include "Mockesp_timer.h"
+#include "Mockesp_transport.h"
+#include "Mockesp_transport_ssl.h"
+#include "Mockesp_transport_tcp.h"
+#include "Mockesp_transport_ws.h"
+#include "Mockevent_groups.h"
+#include "Mockqueue.h"
+#include "Mocktask.h"
+#if __has_include("Mockidf_additions.h")
+    /* Some functions were moved from "task.h" to "idf_additions.h" */
+#include "Mockidf_additions.h"
+#endif
+}
+
+using unique_mqtt_client =
+    std::unique_ptr < std::remove_pointer_t<esp_mqtt_client_handle_t>,
+    decltype([](esp_mqtt_client_handle_t client)
+{
+    esp_mqtt_client_destroy(client);
+}) >;
+
+static esp_err_t validate_subscribe(const esp_mqtt5_subscribe_property_config_t &property, bool shared_available = true)
+{
+    return test_mqtt5_validate_subscribe_property(&property, shared_available, MQTT_PROTOCOL_V_5);
+}
+
+static esp_err_t validate_unsubscribe(const esp_mqtt5_unsubscribe_property_config_t &property,
+                                      bool shared_available = true)
+{
+    return test_mqtt5_validate_unsubscribe_property(&property, shared_available, MQTT_PROTOCOL_V_5);
+}
+
+static esp_err_t validate_publish(const esp_mqtt5_publish_property_config_t &property, uint16_t topic_alias_maximum = 10)
+{
+    return test_mqtt5_validate_publish_property(&property, topic_alias_maximum, MQTT_PROTOCOL_V_5);
 }
 
 TEST_CASE("MQTT5 inflight quota uses an exact upper bound")
@@ -22,4 +74,147 @@ TEST_CASE("MQTT5 inflight quota uses an exact upper bound")
 TEST_CASE("MQTT5 first send on a connection counts even when PUBLISH has DUP set")
 {
     REQUIRE(test_mqtt5_increment_packet_counter_with_dup() == 1);
+}
+
+TEST_CASE("MQTT5 shared subscribe property needs a usable share name")
+{
+    // mqtt5_msg_subscribe() calls strlen(share_name) unconditionally once
+    // is_share_subscribe is set, so these two must never reach the encoder.
+    esp_mqtt5_subscribe_property_config_t no_name = {};
+    no_name.is_share_subscribe = true;
+    REQUIRE(validate_subscribe(no_name) == ESP_FAIL);
+    esp_mqtt5_subscribe_property_config_t empty_name = {};
+    empty_name.is_share_subscribe = true;
+    empty_name.share_name = "";
+    REQUIRE(validate_subscribe(empty_name) == ESP_FAIL);
+    // Control: the same property with a share name is legal and must pass.
+    esp_mqtt5_subscribe_property_config_t named = {};
+    named.is_share_subscribe = true;
+    named.share_name = "group";
+    REQUIRE(validate_subscribe(named) == ESP_OK);
+    // ... but only when the broker advertised shared-subscription support.
+    REQUIRE(validate_subscribe(named, /*shared_available=*/false) == ESP_FAIL);
+}
+
+TEST_CASE("MQTT5 shared unsubscribe property needs a usable share name")
+{
+    esp_mqtt5_unsubscribe_property_config_t no_name = {};
+    no_name.is_share_subscribe = true;
+    REQUIRE(validate_unsubscribe(no_name) == ESP_FAIL);
+    esp_mqtt5_unsubscribe_property_config_t named = {};
+    named.is_share_subscribe = true;
+    named.share_name = "group";
+    REQUIRE(validate_unsubscribe(named) == ESP_OK);
+    REQUIRE(validate_unsubscribe(named, /*shared_available=*/false) == ESP_FAIL);
+}
+
+TEST_CASE("MQTT5 rejects No Local on a shared subscription")
+{
+    // MQTT-3.8.3-4 forbids the combination; the broker answers with a
+    // protocol-error DISCONNECT rather than a SUBACK.
+    esp_mqtt5_subscribe_property_config_t property = {};
+    property.is_share_subscribe = true;
+    property.share_name = "group";
+    property.no_local_flag = true;
+    REQUIRE(validate_subscribe(property) == ESP_FAIL);
+    // Control: No Local on a non-shared subscription is legal.
+    esp_mqtt5_subscribe_property_config_t unshared = {};
+    unshared.no_local_flag = true;
+    REQUIRE(validate_subscribe(unshared) == ESP_OK);
+}
+
+TEST_CASE("MQTT5 subscribe retain_handle is limited to 0, 1, 2")
+{
+    esp_mqtt5_subscribe_property_config_t property = {};
+
+    for (uint8_t handle = 0; handle <= 2; ++handle) {
+        property.retain_handle = handle;
+        REQUIRE(validate_subscribe(property) == ESP_OK);
+    }
+
+    property.retain_handle = 3;
+    REQUIRE(validate_subscribe(property) == ESP_FAIL);
+}
+
+TEST_CASE("MQTT5 publish topic alias is bounded by the server maximum")
+{
+    esp_mqtt5_publish_property_config_t property = {};
+    property.topic_alias = 11;
+    REQUIRE(validate_publish(property, /*topic_alias_maximum=*/10) == ESP_FAIL);
+    // Control: the maximum itself is a valid alias.
+    property.topic_alias = 10;
+    REQUIRE(validate_publish(property, /*topic_alias_maximum=*/10) == ESP_OK);
+    // A server that advertised no alias support rejects every alias.
+    property.topic_alias = 1;
+    REQUIRE(validate_publish(property, /*topic_alias_maximum=*/0) == ESP_FAIL);
+}
+
+TEST_CASE("MQTT5 properties are rejected on a non-v5 connection")
+{
+    const esp_mqtt5_publish_property_config_t publish = {};
+    const esp_mqtt5_subscribe_property_config_t subscribe = {};
+    const esp_mqtt5_unsubscribe_property_config_t unsubscribe = {};
+    REQUIRE(test_mqtt5_validate_publish_property(&publish, 10, MQTT_PROTOCOL_V_3_1_1) == ESP_FAIL);
+    REQUIRE(test_mqtt5_validate_subscribe_property(&subscribe, true, MQTT_PROTOCOL_V_3_1_1) == ESP_FAIL);
+    REQUIRE(test_mqtt5_validate_unsubscribe_property(&unsubscribe, true, MQTT_PROTOCOL_V_3_1_1) == ESP_FAIL);
+    // A NULL property means "no properties" and is accepted on any version.
+    REQUIRE(test_mqtt5_validate_publish_property(nullptr, 10, MQTT_PROTOCOL_V_3_1_1) == ESP_OK);
+    REQUIRE(test_mqtt5_validate_subscribe_property(nullptr, true, MQTT_PROTOCOL_V_3_1_1) == ESP_OK);
+    REQUIRE(test_mqtt5_validate_unsubscribe_property(nullptr, true, MQTT_PROTOCOL_V_3_1_1) == ESP_OK);
+}
+
+SCENARIO("MQTT5 per-message publish property does not consume the staged one")
+{
+    // Same mock preamble the mqtt_client host tests use to build a real client.
+    int mtx = 0;
+    int transport_list = 0;
+    int transport = 0;
+    int event_group = 0;
+    esp_timer_get_time_IgnoreAndReturn(0);
+    xQueueTakeMutexRecursive_IgnoreAndReturn(true);
+    xQueueGiveMutexRecursive_IgnoreAndReturn(true);
+    xQueueCreateMutex_ExpectAnyArgsAndReturn(reinterpret_cast<QueueHandle_t>(&mtx));
+    xEventGroupCreate_IgnoreAndReturn(reinterpret_cast<EventGroupHandle_t>(&event_group));
+    esp_transport_list_init_IgnoreAndReturn(reinterpret_cast<esp_transport_list_handle_t>(&transport_list));
+    esp_transport_tcp_init_IgnoreAndReturn(reinterpret_cast<esp_transport_handle_t>(&transport));
+    esp_transport_ssl_init_IgnoreAndReturn(reinterpret_cast<esp_transport_handle_t>(&transport));
+    esp_transport_ws_init_IgnoreAndReturn(reinterpret_cast<esp_transport_handle_t>(&transport));
+    esp_transport_ws_set_subprotocol_IgnoreAndReturn(ESP_OK);
+    esp_transport_list_add_IgnoreAndReturn(ESP_OK);
+    esp_transport_set_default_port_IgnoreAndReturn(ESP_OK);
+    esp_event_loop_create_IgnoreAndReturn(ESP_OK);
+    esp_event_loop_delete_IgnoreAndReturn(ESP_OK);
+    esp_transport_list_destroy_IgnoreAndReturn(ESP_OK);
+    esp_transport_destroy_IgnoreAndReturn(ESP_OK);
+    xTaskCreatePinnedToCore_IgnoreAndReturn(pdTRUE);
+    vEventGroupDelete_Ignore();
+    vQueueDelete_Ignore();
+    GIVEN("A v5 client with a staged publish property") {
+        esp_mqtt_client_config_t config{};
+        config.broker.address.uri = "mqtt://1.1.1.1";
+        config.session.protocol_ver = MQTT_PROTOCOL_V_5;
+        auto client = unique_mqtt_client{esp_mqtt_client_init(&config)};
+        REQUIRE(client != nullptr);
+        // The client stays disconnected on purpose: the publish still runs
+        // through make_publish(), which is where the staged property is
+        // consumed, and only then bails out at the "not connected" check.
+        const esp_mqtt5_publish_property_config_t staged = { .message_expiry_interval = 60 };
+        REQUIRE(esp_mqtt5_client_set_publish_property(client.get(), &staged) == ESP_OK);
+        REQUIRE(test_mqtt5_staged_publish_property(client.get()) == &staged);
+        WHEN("A per-message property is published") {
+            const esp_mqtt5_publish_property_config_t per_message = { .message_expiry_interval = 5 };
+            esp_mqtt_client_publish5(client.get(), "topic", "data", 0, 0, 0, &per_message);
+            THEN("The staged property is left for the next plain publish") {
+                // Otherwise a publish5() on one task silently strips the
+                // properties off a publish() another task already staged.
+                REQUIRE(test_mqtt5_staged_publish_property(client.get()) == &staged);
+            }
+        }
+        WHEN("A plain publish is made") {
+            esp_mqtt_client_publish(client.get(), "topic", "data", 0, 0, 0);
+            THEN("The staged one-shot property is consumed as before") {
+                REQUIRE(test_mqtt5_staged_publish_property(client.get()) == nullptr);
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Add MQTT v5 API variants — `esp_mqtt_client_publish5`, `esp_mqtt_client_enqueue5`, `esp_mqtt_client_subscribe5`, `esp_mqtt_client_unsubscribe5` — that take the property configuration for the message being sent and apply it **atomically**, inside the existing `MQTT_API_LOCK` critical section.

Today the only way to attach MQTT v5 properties to a PUBLISH/SUBSCRIBE/UNSUBSCRIBE is the client-scoped `esp_mqtt5_client_set_*_property` API. That needs two calls (set, then send), and between them any other task can overwrite or consume the staged property — so there is no way to send per-message properties safely from more than one task.

### Semantics

- A **non-NULL** `property` is used **instead of** anything staged via `esp_mqtt5_client_set_*_property`. The two are **not** merged, and the staged property is left untouched for the next plain `esp_mqtt_client_publish` / `subscribe` / `unsubscribe`.
- A **NULL** `property` falls back to the staged property and consumes it, exactly like the existing functions. Passing NULL is behavior-identical to calling the non-`5` variant.
- `property` is validated exactly as the corresponding setter validates it, and an invalid one is **rejected** (`-1` / `ESP_FAIL`) rather than encoded onto the wire.

Replacement rather than merging is deliberate. The staged property is a one-shot that the next message consumes, so it is not a persistent "base" to layer onto; and because the config structs carry no presence flags, a merge cannot express "send this message with `message_expiry_interval = 0`" once a non-zero value is staged — zero is indistinguishable from unset.

## Why properties belong to the message, per the MQTT 5.0 specification

References are to [MQTT Version 5.0, OASIS Standard, 07 March 2019](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html). Every link is a section anchor in that published HTML.

MQTT 5.0 carries these properties in the **Variable Header of each individual packet**, not in connection state:

| Scope | Section |
|---|---|
| PUBLISH packet | [§3.3.2.3 PUBLISH Properties](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901109) |
| SUBSCRIBE packet | [§3.8.2.1 SUBSCRIBE Properties](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901164) |
| UNSUBSCRIBE packet | [§3.10.2.1 UNSUBSCRIBE Properties](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901182) |
| Connection (the one genuinely client-scoped set) | [§3.1.2.11 CONNECT Properties](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901046) |

Three properties make the packet scope explicit:

- [§3.3.2.3.4 Topic Alias](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901113) — *"It is a Protocol Error to include the Topic Alias value more than once."* An alias held as client state is re-applied to every later PUBLISH, which is not what the alias denotes.
- [§3.3.2.3.3 Message Expiry Interval](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901112) — *"If present, the Four Byte value is the lifetime of the Application Message in seconds."* The lifetime belongs to one Application Message.
- [§3.3.2.3.7 User Property](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901116) — *"The Server MUST send all User Properties unaltered in a PUBLISH packet when forwarding the Application Message to a Client [MQTT-3.3.2-17]."* The pairs travel with that one message.

The same holds on the subscription side: [§3.8.2.1.3](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901167) and [§3.10.2.1.2](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901184) both state that *"User Properties on the SUBSCRIBE packet can be used to send subscription related properties from the Client to the Server"* (respectively UNSUBSCRIBE) — per request, not per client.

## Implementation notes

- `esp_mqtt5_client_set_*_property` was not only a store — it was the only place properties were validated. That validation is now extracted into `esp_mqtt5_client_validate_{publish,subscribe,unsubscribe}_property()` (declared in `lib/include/mqtt5_client_priv.h`) and called from **both** the setters and the four new entry points, so a property is checked exactly once wherever it enters the library.
- Without that, a per-message property would reach the encoder unchecked. Concretely, `esp_mqtt_client_subscribe5(c, "t", 1, &(esp_mqtt5_subscribe_property_config_t){.is_share_subscribe = true})` with no `share_name` reaches `strlen(property->share_name)` in `mqtt5_msg_subscribe()`, which is a NULL dereference — a LoadProhibited panic on target.
- `make_publish`, `mqtt_client_subscribe_multiple_internal` and `esp_mqtt_client_unsubscribe_internal` take the optional per-message property (compiled out when `CONFIG_MQTT_PROTOCOL_5` is off) and only clear the staged one when the caller did not supply their own.
- The setters additionally stop dereferencing a NULL `property`.
- `esp_mqtt_client_publish` is deduplicated into `esp_mqtt_client_publish_internal`, matching the pattern used for `unsubscribe` and `enqueue`, so the publish path is not maintained in two copies.

**One behavior change worth flagging for review:** `retain_handle > 2` is now rejected. The encoder silently clamps it (it only applies values in `(0,3)`), so today an out-of-range value yields a subscription with different retain-handling than requested plus a success return. Rejecting matches what `esp_mqtt5_client_set_subscribe_property` already does — but if clamping is preferred, that check is one line to drop.

## Testing

Host tests (`test/host`, linux target, ASAN + UBSAN), built the way CI builds them:

```
All tests passed (94 assertions in 12 test cases)
```

| | ESP-IDF v5.5 | ESP-IDF v6.0.2 |
|---|---|---|
| Build, `CONFIG_MQTT_PROTOCOL_5=y` | pass | pass |
| Host tests | 94 assertions / 12 cases | 94 assertions / 12 cases |
| `mqtt_client.c`, `CONFIG_MQTT_PROTOCOL_5=n` | compiles | compiles |

Seven new test cases cover the four entry points and the validators, each rejection paired with a passing control so a gate that stopped rejecting would be caught. The suite was checked against deliberate regressions: removing the "don't consume the staged property" guard fails one case (its control still passes), and stubbing the subscribe/unsubscribe validators to `ESP_OK` fails five — so the assertions are not vacuous. Calling the encoder directly with `is_share_subscribe = true, share_name = NULL` reproduces the crash under UBSAN: `mqtt5_msg.c:1295: null pointer passed as argument 1, which is declared to never be null`.

`astyle` 3.4.7 passes with the repo rules (`.ci/astyle-rules.yml`); commit messages follow the conventional-commit config (types `feat`/`fix`/`refactor`, scope `mqtt5`).

Known gap: the host *test project* does not build with `CONFIG_MQTT_PROTOCOL_5=n`, because `mqtt5_client_test_adapter.c` uses `mqtt5_config_storage_t` unconditionally. That predates this change and is left alone.
