### PR TITLE
fix: wake MQTT task when stopping during reconnect wait (IDFGH-18201) (IDFGH-18203)

### DIFF
--- a/mqtt_client.c
+++ b/mqtt_client.c
@@ -2330,6 +2330,7 @@ esp_err_t esp_mqtt_client_stop(esp_mqtt_client_handle_t client)
 
         client->run = false;
         client->state = MQTT_STATE_DISCONNECTED;
+        xEventGroupSetBits(client->status_bits, RECONNECT_BIT);
         MQTT_API_UNLOCK(client);
         xEventGroupWaitBits(client->status_bits, STOPPED_BIT, false, true, portMAX_DELAY);
         return ESP_OK;

--- a/test/host/main/CMakeLists.txt
+++ b/test/host/main/CMakeLists.txt
@@ -1,4 +1,4 @@
-idf_component_register(SRCS  "test_mqtt_client.cpp" "test_mqtt5_client.cpp" "mqtt5_client_test_adapter.c" "test_log_intercept.cpp" "test_log_matchers.cpp" "test_log_parser.cpp"
+idf_component_register(SRCS  "test_mqtt_client.cpp" "test_mqtt5_client.cpp" "mqtt_client_test_adapter.c" "mqtt5_client_test_adapter.c" "test_log_intercept.cpp" "test_log_matchers.cpp" "test_log_parser.cpp"
                        REQUIRES cmock mqtt esp_timer esp_hw_support http_parser log
                        WHOLE_ARCHIVE)
 

--- a/test/host/main/mqtt_client_test_adapter.c
+++ b/test/host/main/mqtt_client_test_adapter.c
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "mqtt_client_priv.h"
+
+void test_mqtt_client_enter_reconnect_wait(esp_mqtt_client_handle_t client)
+{
+    static int mqtt_task;
+
+    client->run = true;
+    client->state = MQTT_STATE_WAIT_RECONNECT;
+    client->task_handle = (TaskHandle_t)&mqtt_task;
+}

--- a/test/host/main/test_mqtt_client.cpp
+++ b/test/host/main/test_mqtt_client.cpp
@@ -34,6 +34,7 @@ extern "C" {
 #include "Mockidf_additions.h"
 #endif
 #include "Mockesp_timer.h"
+    void test_mqtt_client_enter_reconnect_wait(esp_mqtt_client_handle_t client);
     /*
      * The following functions are not directly called but the generation of them
      * from cmock is broken, so we need to define them here.
@@ -100,6 +101,42 @@ static BaseType_t fail_to_create_fake_task(TaskFunction_t, const char *const, co
                                            const BaseType_t, int)
 {
     return pdFALSE;
+}
+
+struct stop_wake_trace_t {
+    EventGroupHandle_t event_group;
+    int phase;
+    bool invalid_call;
+};
+
+static stop_wake_trace_t stop_wake_trace;
+
+static EventBits_t track_event_group_set_bits(EventGroupHandle_t event_group,
+                                              EventBits_t bits, int)
+{
+    static constexpr EventBits_t reconnect_bit = 1U << 1;
+
+    if (event_group != stop_wake_trace.event_group || bits != reconnect_bit ||
+            stop_wake_trace.phase != 0) {
+        stop_wake_trace.invalid_call = true;
+    }
+    stop_wake_trace.phase = 1;
+    return bits;
+}
+
+static EventBits_t track_event_group_wait_bits(EventGroupHandle_t event_group,
+                                               EventBits_t bits, BaseType_t clear_on_exit,
+                                               BaseType_t wait_for_all, TickType_t ticks_to_wait,
+                                               int)
+{
+    static constexpr EventBits_t stopped_bit = 1U << 0;
+
+    if (event_group != stop_wake_trace.event_group || bits != stopped_bit || clear_on_exit ||
+            !wait_for_all || ticks_to_wait != portMAX_DELAY || stop_wake_trace.phase != 1) {
+        stop_wake_trace.invalid_call = true;
+    }
+    stop_wake_trace.phase = 2;
+    return stopped_bit;
 }
 
 SCENARIO("MQTT Client Operation")
@@ -334,6 +371,19 @@ SCENARIO("MQTT Client Operation")
                 REQUIRE_THAT(log, HasMessageIn("mqtt_client", "Core selection"));
                 // Only need to start the client, destroy is called automatically at the
                 // end of scope
+            }
+            SECTION("Stop wakes a client waiting to reconnect") {
+                test_mqtt_client_enter_reconnect_wait(client.get());
+                stop_wake_trace = {
+                    reinterpret_cast<EventGroupHandle_t>(&event_group), 0, false
+                };
+                xTaskGetCurrentTaskHandle_IgnoreAndReturn(nullptr);
+                xEventGroupSetBits_Stub(track_event_group_set_bits);
+                xEventGroupWaitBits_Stub(track_event_group_wait_bits);
+
+                REQUIRE(esp_mqtt_client_stop(client.get()) == ESP_OK);
+                REQUIRE(stop_wake_trace.phase == 2);
+                REQUIRE_FALSE(stop_wake_trace.invalid_call);
             }
             SECTION("get_state reports client lifecycle correctly") {
                 SECTION("returns NOT_INITIALIZED for null handle") {


### PR DESCRIPTION
## Summary

- Wake the MQTT task when `esp_mqtt_client_stop()` is called while it is waiting to reconnect.
- Add a host regression test that verifies the reconnect wake happens before the caller waits for task shutdown.

## Problem

I encountered this in a battery-powered ESP32-S3 application that performs a short MQTT exchange and then enters deep sleep.

After a connection failure, `esp_mqtt_abort_connection()` moves the client to `MQTT_STATE_WAIT_RECONNECT`. In that state, the MQTT task releases the API lock and waits on `RECONNECT_BIT` for up to half of `reconnect_timeout_ms` (approximately 5 seconds with the default configuration).

If the application calls `esp_mqtt_client_stop()` during this wait, the function sets `run` to `false` and waits indefinitely for `STOPPED_BIT`, but it does not wake the MQTT task. The task therefore cannot observe `run == false` until its reconnect wait expires.

This is particularly noticeable when automatic reconnect is disabled and the application owns the retry and power-management policy. A failed connection followed by `esp_mqtt_client_stop()` can keep the system active for several unnecessary seconds before it can enter sleep.

## Fix

Set `RECONNECT_BIT` after publishing the stopped state and before releasing the API lock:

```c
client->run = false;
client->state = MQTT_STATE_DISCONNECTED;
xEventGroupSetBits(client->status_bits, RECONNECT_BIT);
```

The waiting task wakes, returns to the loop boundary, observes `run == false`, performs its existing cleanup, and sets `STOPPED_BIT` normally.

## Why this is safe

- There is no public API or ABI change.
- The behavior is the same with automatic reconnect enabled or disabled: the task exits at the loop boundary before processing either reconnect branch.
- Event-group bits are latched, so the wake is not lost if `stop()` runs immediately before the task begins waiting.
- A subsequent MQTT task clears `RECONNECT_BIT` during `MQTT_STATE_INIT`.
- Connected-client disconnect behavior is unchanged.

## Testing

- Built the host test application with ESP-IDF 6.1.
- Ran the complete host suite: 100 RapidCheck cases and 79 assertions in 5 test cases passed.
- Mutation-checked the regression test: removing the wake call makes `Stop wakes a client waiting to reconnect` fail specifically because the shutdown wait starts before the reconnect wake.

## Related work

This change is complementary to #315. That PR makes the stop request asynchronous for the caller, but the MQTT task still needs this wake to complete shutdown promptly while it is in `MQTT_STATE_WAIT_RECONNECT`. If #315 is merged first, the wake belongs in its common stop-initiation path so both blocking and asynchronous stop use it.

Related: #314